### PR TITLE
Fix #164: Remove hard pytest dependency

### DIFF
--- a/polyfactory/fields.py
+++ b/polyfactory/fields.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Generic, TypeVar, cast
 from typing_extensions import ParamSpec, TypedDict
 
 from polyfactory.exceptions import ParameterException
-from polyfactory.pytest_plugin import FactoryFixture
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -105,6 +104,7 @@ class Fixture:
 
         :returns: The build result.
         """
+        from polyfactory.pytest_plugin import FactoryFixture
 
         if factory := FactoryFixture.factory_class_map.get(self.fixture["value"]):
             if self.size:


### PR DESCRIPTION
Fixes #164 by removing the hard dependency on pytest. Pytest will now only be imported when the `Fixture` field is being used.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to: 
- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
