### PR TITLE
Make polyfactory work with Ellipsis in dataclasses

### DIFF
--- a/polyfactory/constants.py
+++ b/polyfactory/constants.py
@@ -29,3 +29,5 @@ TYPE_MAPPING = {
     abc.Sequence: list,
     abc.Set: set,
 }
+
+IGNORED_TYPE_ARGS: Set = {Ellipsis}

--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-
 from typing import Any, TypedDict, Pattern, TYPE_CHECKING
 
-
-from polyfactory.constants import TYPE_MAPPING
+from polyfactory.constants import TYPE_MAPPING, IGNORED_TYPE_ARGS
 from polyfactory.utils.helpers import unwrap_args, unwrap_new_type
 
 if TYPE_CHECKING:
@@ -69,7 +67,11 @@ class FieldMeta:
 
         :returns: a tuple of types.
         """
-        return tuple(TYPE_MAPPING[arg] if arg in TYPE_MAPPING else arg for arg in unwrap_args(self.annotation))
+        return tuple(
+            TYPE_MAPPING[arg] if arg in TYPE_MAPPING else arg
+            for arg in unwrap_args(self.annotation)
+            if arg not in IGNORED_TYPE_ARGS
+        )
 
     @classmethod
     def from_type(

--- a/tests/test_dataclass_factory.py
+++ b/tests/test_dataclass_factory.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass as vanilla_dataclass
 from dataclasses import field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from pydantic.dataclasses import Field  # type: ignore
 from pydantic.dataclasses import dataclass as pydantic_dataclass
@@ -129,3 +129,17 @@ def test_complex_embedded_dataclass() -> None:
     assert list(result.weirdly_nest_field[0].values())[0].values()
     assert list(list(result.weirdly_nest_field[0].values())[0].values())[0]
     assert isinstance(list(list(result.weirdly_nest_field[0].values())[0].values())[0], VanillaDC)
+
+
+def test_tuple_ellipsis_in_vanilla_dc() -> None:
+    @vanilla_dataclass
+    class VanillaDC:
+        ids: Tuple[int, ...]
+
+    class MyFactory(DataclassFactory[VanillaDC]):
+        __model__ = VanillaDC
+
+    result = MyFactory.build()
+
+    assert result
+    assert result.ids


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to: 
- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
User claims that `tuple[int, ...]` doesn't work with `dataclasses`. I've added a test and it's true. It works however for `pydantic`, because `pydantic` doesn't return Ellipsis' in fields representation.

I've added a test that fails for given scenario. I've then added a set of types to ignore.

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

Fixes: https://github.com/litestar-org/polyfactory/issues/181
