### PR TITLE
Fix missing f-string when raising `ConfigurationException` for unsupported model type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@
 [![Medium](https://img.shields.io/badge/Medium-12100E?style=flat&logo=medium&logoColor=white)](https://blog.litestar.dev)
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 </div>

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -207,7 +207,7 @@ class BaseFactory(ABC, Generic[T]):
                             f"o resolve this error, subclass the factory from {factory.__name__} instead of {cls.__name__}"
                         )
                     raise ConfigurationException(
-                        "Model type {model.__name__} is not supported. "
+                        f"Model type {model.__name__} is not supported. "
                         "To support it, register an appropriate base factory and subclass it for your factory."
                     )
 

--- a/tests/test_factory_subclassing.py
+++ b/tests/test_factory_subclassing.py
@@ -23,7 +23,7 @@ def test_factory_raises_config_error_for_unsupported_model_with_supported_factor
 
 
 def test_factory_raises_config_error_for_unsupported_model() -> None:
-    with pytest.raises(ConfigurationException):
+    with pytest.raises(ConfigurationException, match="Model type Null is not supported"):
 
         class MyFactory(ModelFactory):
             __model__ = Null


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md) for this repository."

- [x] New code has 100% test coverage
- ~[ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR~
- ~[ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR~

### Description

Fix error message when model type is not supported:
```
polyfactory.exceptions.ConfigurationException: Model type {model.__name__} is not supported. To support it, register an appropriate base factory and subclass it for your factory.
```
