### PR TITLE
change how inner container type gets sourced

### DIFF
--- a/polyfactory/value_generators/complex_types.py
+++ b/polyfactory/value_generators/complex_types.py
@@ -40,10 +40,10 @@ def handle_container_type(
     elif field_meta.children:
         if isinstance(container, (list, deque)):
             container.append(
-    factory.get_field_value(
-        field_meta=factory.__random__.choice(
-            field_meta.children),
-             field_build_parameters=None) )
+                factory.get_field_value(
+                    field_meta=factory.__random__.choice(field_meta.children), field_build_parameters=None
+                )
+            )
         else:
             container.add(
                 handle_complex_type(

--- a/polyfactory/value_generators/complex_types.py
+++ b/polyfactory/value_generators/complex_types.py
@@ -40,11 +40,10 @@ def handle_container_type(
     elif field_meta.children:
         if isinstance(container, (list, deque)):
             container.append(
-                handle_complex_type(
-                    field_meta=factory.__random__.choice(field_meta.children),
-                    factory=factory,
-                )
-            )
+    factory.get_field_value(
+        field_meta=factory.__random__.choice(
+            field_meta.children),
+             field_build_parameters=None) )
         else:
             container.add(
                 handle_complex_type(

--- a/tests/test_complex_types.py
+++ b/tests/test_complex_types.py
@@ -7,6 +7,7 @@ from typing import (
     FrozenSet,
     Iterable,
     List,
+    Literal,
     Optional,
     Sequence,
     Set,
@@ -27,6 +28,7 @@ def test_handles_complex_typing() -> None:
         nested_dict: Dict[str, Dict[Union[int, str], Dict[Any, List[Dict[str, str]]]]]
         dict_str_any: Dict[str, Any]
         nested_list: List[List[List[Dict[str, List[Any]]]]]
+        literal_list: List[Literal[1, 2, 3]]
         sequence_dict: Sequence[Dict]
         iterable_float: Iterable[float]
         tuple_ellipsis: Tuple[int, ...]
@@ -43,6 +45,7 @@ def test_handles_complex_typing() -> None:
     assert result.nested_dict
     assert result.dict_str_any
     assert result.nested_list
+    assert result.literal_list
     assert result.sequence_dict
     assert result.iterable_float
     assert result.tuple_ellipsis
@@ -57,6 +60,7 @@ def test_handles_complex_typing_with_embedded_models() -> None:
     class MyModel(BaseModel):
         person_dict: Dict[str, Person]
         person_list: List[Person]
+        person_literal_list: List[Literal["Person"]]
 
     class MyFactory(ModelFactory):
         __model__ = MyModel
@@ -65,6 +69,8 @@ def test_handles_complex_typing_with_embedded_models() -> None:
 
     assert result.person_dict
     assert result.person_list[0].pets
+    assert isinstance(result.person_literal_list[0], str)
+    assert result.person_literal_list[0] == "Person"
 
 
 def test_raises_for_user_defined_types() -> None:


### PR DESCRIPTION
[/x/]: # "By submitting this pull request, you agree to:"
[/x/]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[/x/]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

[/x/]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description

This PR aims to solve model creation where the inner type of a container is a Literal.

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
