### PR TITLE
Bson field support for odmantic models

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -31,7 +31,7 @@ from typing import (
     TypeVar,
     cast,
 )
-from uuid import NAMESPACE_DNS, UUID, uuid1, uuid3, uuid5
+from uuid import UUID
 
 from faker import Faker
 from typing_extensions import get_args
@@ -68,59 +68,6 @@ if TYPE_CHECKING:
     from polyfactory.persistence import AsyncPersistenceProtocol, SyncPersistenceProtocol
     from polyfactory.field_meta import FieldMeta, Constraints
     from typing_extensions import TypeGuard
-
-
-def _create_pydantic_type_map(cls: "type[BaseFactory]") -> dict[type, Callable[[], Any]]:
-    """Creates a mapping of pydantic types to mock data functions.
-
-    :param cls: The base factory class.
-    :return: A dict mapping types to callables.
-    """
-    try:
-        import pydantic
-
-        return {
-            pydantic.ByteSize: cls.__faker__.pyint,
-            pydantic.PositiveInt: cls.__faker__.pyint,
-            pydantic.FilePath: lambda: Path(realpath(__file__)),
-            pydantic.NegativeFloat: lambda: cls.__random__.uniform(-100, -1),
-            pydantic.NegativeInt: lambda: cls.__faker__.pyint() * -1,
-            pydantic.PositiveFloat: cls.__faker__.pyint,
-            pydantic.NonPositiveFloat: lambda: cls.__random__.uniform(-100, 0),
-            pydantic.NonNegativeInt: cls.__faker__.pyint,
-            pydantic.StrictInt: cls.__faker__.pyint,
-            pydantic.StrictBool: cls.__faker__.pybool,
-            pydantic.StrictBytes: partial(create_random_bytes, cls.__random__),
-            pydantic.StrictFloat: cls.__faker__.pyfloat,
-            pydantic.StrictStr: cls.__faker__.pystr,
-            pydantic.DirectoryPath: lambda: Path(realpath(__file__)).parent,
-            pydantic.EmailStr: cls.__faker__.free_email,
-            pydantic.NameEmail: cls.__faker__.free_email,
-            pydantic.PyObject: lambda: "decimal.Decimal",  # type: ignore[dict-item]
-            pydantic.color.Color: cls.__faker__.hex_color,  # pyright: ignore
-            pydantic.Json: cls.__faker__.json,
-            pydantic.PaymentCardNumber: cls.__faker__.credit_card_number,
-            pydantic.AnyUrl: cls.__faker__.url,
-            pydantic.AnyHttpUrl: cls.__faker__.url,
-            pydantic.HttpUrl: cls.__faker__.url,
-            pydantic.PostgresDsn: lambda: "postgresql://user:secret@localhost",
-            pydantic.RedisDsn: lambda: "redis://localhost:6379",
-            pydantic.UUID1: uuid1,
-            pydantic.UUID3: lambda: uuid3(NAMESPACE_DNS, cls.__faker__.pystr()),
-            pydantic.UUID4: cls.__faker__.uuid4,
-            pydantic.UUID5: lambda: uuid5(NAMESPACE_DNS, cls.__faker__.pystr()),
-            pydantic.SecretBytes: partial(create_random_bytes, cls.__random__),
-            pydantic.SecretStr: cls.__faker__.pystr,
-            pydantic.IPvAnyAddress: cls.__faker__.ipv4,
-            pydantic.IPvAnyInterface: cls.__faker__.ipv4,
-            pydantic.IPvAnyNetwork: lambda: cls.__faker__.ipv4(network=True),
-            pydantic.AmqpDsn: lambda: "amqps://",
-            pydantic.KafkaDsn: lambda: "kafka://",
-            pydantic.PastDate: cls.__faker__.past_date,
-            pydantic.FutureDate: cls.__faker__.future_date,
-        }
-    except ImportError:
-        return {}
 
 
 T = TypeVar("T")
@@ -429,7 +376,6 @@ class BaseFactory(ABC, Generic[T]):
             # types
             Callable: _create_generic_fn,
             Counter: lambda: Counter(cls.__faker__.pystr()),
-            **_create_pydantic_type_map(cls),
         }
 
     @classmethod

--- a/polyfactory/factories/odmantic_odm_factory.py
+++ b/polyfactory/factories/odmantic_odm_factory.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union
+
+import decimal
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, Union
 
 from polyfactory.exceptions import MissingDependencyException
 from polyfactory.factories.pydantic_factory import ModelFactory
 from polyfactory.fields import Ignore
 from polyfactory.utils.predicates import is_safe_subclass
+from polyfactory.value_generators.primitives import create_random_bytes
 
 try:
-    from odmantic import EmbeddedModel, Model
+    from bson.decimal128 import Decimal128, create_decimal128_context
+    from odmantic import EmbeddedModel, Model, bson as odbson
 
 except ImportError as e:
     raise MissingDependencyException("odmantic is not installed") from e
@@ -33,3 +37,25 @@ class OdmanticModelFactory(Generic[T], ModelFactory[T]):
         return is_safe_subclass(value, Model) or is_safe_subclass(value, EmbeddedModel)
 
     id = Ignore()
+
+    @classmethod
+    def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:
+        provider_map = super().get_provider_map()
+        provider_map.update(
+            {
+                odbson.Int64: lambda: odbson.Int64.validate(cls.__faker__.pyint()),
+                odbson.Decimal128: lambda: _to_decimal128(cls.__faker__.pydecimal()),
+                odbson.Binary: lambda: odbson.Binary.validate(create_random_bytes(cls.__random__)),
+                odbson._datetime: lambda: odbson._datetime.validate(cls.__faker__.date_time_between()),
+                # bson.Regex and bson._Pattern not supported as there is no way to generate
+                # a random regular expression with Faker
+                # bson.Regex:
+                # bson._Pattern:
+            }
+        )
+        return provider_map
+
+
+def _to_decimal128(value: decimal.Decimal) -> Decimal128:
+    with decimal.localcontext(create_decimal128_context()) as ctx:
+        return Decimal128(ctx.create_decimal(value))

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -1,29 +1,22 @@
 from __future__ import annotations
 from contextlib import suppress
 from inspect import isclass
-from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     ClassVar,
     Generic,
     Mapping,
     TypeVar,
     cast,
 )
-from os.path import realpath
-from pathlib import Path
-from uuid import NAMESPACE_DNS, uuid1, uuid3, uuid5
 
 from polyfactory.exceptions import MissingDependencyException
 from polyfactory.factories.base import BaseFactory
 from polyfactory.field_meta import FieldMeta, Null, Constraints
 from polyfactory.utils.helpers import unwrap_new_type
-from polyfactory.value_generators.primitives import create_random_bytes
 
 try:
-    import pydantic
     from pydantic import (
         BaseModel,
     )
@@ -171,50 +164,3 @@ class ModelFactory(Generic[T], BaseFactory[T]):
             return cls.__model__.construct(**processed_kwargs)
 
         return cls.__model__(**processed_kwargs)
-
-    @classmethod
-    def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:
-        provider_map = super().get_provider_map()
-        provider_map.update(
-            {
-                pydantic.ByteSize: cls.__faker__.pyint,
-                pydantic.PositiveInt: cls.__faker__.pyint,
-                pydantic.FilePath: lambda: Path(realpath(__file__)),
-                pydantic.NegativeFloat: lambda: cls.__random__.uniform(-100, -1),
-                pydantic.NegativeInt: lambda: cls.__faker__.pyint() * -1,
-                pydantic.PositiveFloat: cls.__faker__.pyint,
-                pydantic.NonPositiveFloat: lambda: cls.__random__.uniform(-100, 0),
-                pydantic.NonNegativeInt: cls.__faker__.pyint,
-                pydantic.StrictInt: cls.__faker__.pyint,
-                pydantic.StrictBool: cls.__faker__.pybool,
-                pydantic.StrictBytes: partial(create_random_bytes, cls.__random__),
-                pydantic.StrictFloat: cls.__faker__.pyfloat,
-                pydantic.StrictStr: cls.__faker__.pystr,
-                pydantic.DirectoryPath: lambda: Path(realpath(__file__)).parent,
-                pydantic.EmailStr: cls.__faker__.free_email,
-                pydantic.NameEmail: cls.__faker__.free_email,
-                pydantic.PyObject: lambda: "decimal.Decimal",
-                pydantic.color.Color: cls.__faker__.hex_color,  # pyright: ignore
-                pydantic.Json: cls.__faker__.json,
-                pydantic.PaymentCardNumber: cls.__faker__.credit_card_number,
-                pydantic.AnyUrl: cls.__faker__.url,
-                pydantic.AnyHttpUrl: cls.__faker__.url,
-                pydantic.HttpUrl: cls.__faker__.url,
-                pydantic.PostgresDsn: lambda: "postgresql://user:secret@localhost",
-                pydantic.RedisDsn: lambda: "redis://localhost:6379",
-                pydantic.UUID1: uuid1,
-                pydantic.UUID3: lambda: uuid3(NAMESPACE_DNS, cls.__faker__.pystr()),
-                pydantic.UUID4: cls.__faker__.uuid4,
-                pydantic.UUID5: lambda: uuid5(NAMESPACE_DNS, cls.__faker__.pystr()),
-                pydantic.SecretBytes: partial(create_random_bytes, cls.__random__),
-                pydantic.SecretStr: cls.__faker__.pystr,
-                pydantic.IPvAnyAddress: cls.__faker__.ipv4,
-                pydantic.IPvAnyInterface: cls.__faker__.ipv4,
-                pydantic.IPvAnyNetwork: lambda: cls.__faker__.ipv4(network=True),
-                pydantic.AmqpDsn: lambda: "amqps://",
-                pydantic.KafkaDsn: lambda: "kafka://",
-                pydantic.PastDate: cls.__faker__.past_date,
-                pydantic.FutureDate: cls.__faker__.future_date,
-            }
-        )
-        return provider_map

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -1,22 +1,29 @@
 from __future__ import annotations
 from contextlib import suppress
 from inspect import isclass
+from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     ClassVar,
     Generic,
     Mapping,
     TypeVar,
     cast,
 )
+from os.path import realpath
+from pathlib import Path
+from uuid import NAMESPACE_DNS, uuid1, uuid3, uuid5
 
 from polyfactory.exceptions import MissingDependencyException
 from polyfactory.factories.base import BaseFactory
 from polyfactory.field_meta import FieldMeta, Null, Constraints
 from polyfactory.utils.helpers import unwrap_new_type
+from polyfactory.value_generators.primitives import create_random_bytes
 
 try:
+    import pydantic
     from pydantic import (
         BaseModel,
     )
@@ -164,3 +171,50 @@ class ModelFactory(Generic[T], BaseFactory[T]):
             return cls.__model__.construct(**processed_kwargs)
 
         return cls.__model__(**processed_kwargs)
+
+    @classmethod
+    def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:
+        provider_map = super().get_provider_map()
+        provider_map.update(
+            {
+                pydantic.ByteSize: cls.__faker__.pyint,
+                pydantic.PositiveInt: cls.__faker__.pyint,
+                pydantic.FilePath: lambda: Path(realpath(__file__)),
+                pydantic.NegativeFloat: lambda: cls.__random__.uniform(-100, -1),
+                pydantic.NegativeInt: lambda: cls.__faker__.pyint() * -1,
+                pydantic.PositiveFloat: cls.__faker__.pyint,
+                pydantic.NonPositiveFloat: lambda: cls.__random__.uniform(-100, 0),
+                pydantic.NonNegativeInt: cls.__faker__.pyint,
+                pydantic.StrictInt: cls.__faker__.pyint,
+                pydantic.StrictBool: cls.__faker__.pybool,
+                pydantic.StrictBytes: partial(create_random_bytes, cls.__random__),
+                pydantic.StrictFloat: cls.__faker__.pyfloat,
+                pydantic.StrictStr: cls.__faker__.pystr,
+                pydantic.DirectoryPath: lambda: Path(realpath(__file__)).parent,
+                pydantic.EmailStr: cls.__faker__.free_email,
+                pydantic.NameEmail: cls.__faker__.free_email,
+                pydantic.PyObject: lambda: "decimal.Decimal",
+                pydantic.color.Color: cls.__faker__.hex_color,  # pyright: ignore
+                pydantic.Json: cls.__faker__.json,
+                pydantic.PaymentCardNumber: cls.__faker__.credit_card_number,
+                pydantic.AnyUrl: cls.__faker__.url,
+                pydantic.AnyHttpUrl: cls.__faker__.url,
+                pydantic.HttpUrl: cls.__faker__.url,
+                pydantic.PostgresDsn: lambda: "postgresql://user:secret@localhost",
+                pydantic.RedisDsn: lambda: "redis://localhost:6379",
+                pydantic.UUID1: uuid1,
+                pydantic.UUID3: lambda: uuid3(NAMESPACE_DNS, cls.__faker__.pystr()),
+                pydantic.UUID4: cls.__faker__.uuid4,
+                pydantic.UUID5: lambda: uuid5(NAMESPACE_DNS, cls.__faker__.pystr()),
+                pydantic.SecretBytes: partial(create_random_bytes, cls.__random__),
+                pydantic.SecretStr: cls.__faker__.pystr,
+                pydantic.IPvAnyAddress: cls.__faker__.ipv4,
+                pydantic.IPvAnyInterface: cls.__faker__.ipv4,
+                pydantic.IPvAnyNetwork: lambda: cls.__faker__.ipv4(network=True),
+                pydantic.AmqpDsn: lambda: "amqps://",
+                pydantic.KafkaDsn: lambda: "kafka://",
+                pydantic.PastDate: cls.__faker__.past_date,
+                pydantic.FutureDate: cls.__faker__.future_date,
+            }
+        )
+        return provider_map

--- a/tests/test_odmantic_factory.py
+++ b/tests/test_odmantic_factory.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 from typing import Any, List
 from uuid import UUID
 
+import bson
 import pytest
 from odmantic import AIOEngine, EmbeddedModel, Model
 
@@ -19,6 +21,11 @@ class MyEmbeddedDocument(EmbeddedModel):
 
 
 class MyModel(Model):
+    created_on: datetime
+    bson_id: bson.ObjectId
+    bson_int64: bson.Int64
+    bson_dec128: bson.Decimal128
+    bson_binary: bson.Binary
     name: str
     embedded: MyEmbeddedDocument
     embedded_list: List[MyEmbeddedDocument]
@@ -35,6 +42,16 @@ def test_handles_odmantic_models() -> None:
 
     result = MyFactory.build()
 
-    assert result.name
-    assert result.embedded
-    assert result.embedded_list
+    assert isinstance(result.created_on, datetime)
+    assert isinstance(result.bson_id, bson.ObjectId)
+    assert isinstance(result.bson_int64, bson.Int64)
+    assert isinstance(result.bson_dec128, bson.Decimal128)
+    assert isinstance(result.bson_binary, bson.Binary)
+    assert isinstance(result.name, str)
+    assert isinstance(result.embedded, MyEmbeddedDocument)
+    assert isinstance(result.embedded_list, list)
+    for item in result.embedded_list:
+        assert isinstance(item, MyEmbeddedDocument)
+        assert isinstance(item.name, str)
+        assert isinstance(item.serial, UUID)
+        assert isinstance(item.other_embedded_document, OtherEmbeddedDocument)

--- a/tests/test_odmantic_factory.py
+++ b/tests/test_odmantic_factory.py
@@ -12,12 +12,22 @@ from polyfactory.factories.odmantic_odm_factory import OdmanticModelFactory
 class OtherEmbeddedDocument(EmbeddedModel):
     name: str
     serial: UUID
+    created_on: datetime
+    bson_id: bson.ObjectId
+    bson_int64: bson.Int64
+    bson_dec128: bson.Decimal128
+    bson_binary: bson.Binary
 
 
 class MyEmbeddedDocument(EmbeddedModel):
     name: str
     serial: UUID
     other_embedded_document: OtherEmbeddedDocument
+    created_on: datetime
+    bson_id: bson.ObjectId
+    bson_int64: bson.Int64
+    bson_dec128: bson.Decimal128
+    bson_binary: bson.Binary
 
 
 class MyModel(Model):
@@ -54,4 +64,18 @@ def test_handles_odmantic_models() -> None:
         assert isinstance(item, MyEmbeddedDocument)
         assert isinstance(item.name, str)
         assert isinstance(item.serial, UUID)
-        assert isinstance(item.other_embedded_document, OtherEmbeddedDocument)
+        assert isinstance(item.created_on, datetime)
+        assert isinstance(item.bson_id, bson.ObjectId)
+        assert isinstance(item.bson_int64, bson.Int64)
+        assert isinstance(item.bson_dec128, bson.Decimal128)
+        assert isinstance(item.bson_binary, bson.Binary)
+
+        other = item.other_embedded_document
+        assert isinstance(other, OtherEmbeddedDocument)
+        assert isinstance(other.name, str)
+        assert isinstance(other.serial, UUID)
+        assert isinstance(other.created_on, datetime)
+        assert isinstance(other.bson_id, bson.ObjectId)
+        assert isinstance(other.bson_int64, bson.Int64)
+        assert isinstance(other.bson_dec128, bson.Decimal128)
+        assert isinstance(other.bson_binary, bson.Binary)


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage

### Description

Support bson fields for `odmantic` models.

~Currently in draft as it still fails for `odmantic.EmbeddedModel` due to a different issue: the selected factory for `odmantic.EmbeddedModel` is the (pydantic) `ModelFactory` instead of `OdmanticModelFactory`. Both these factories return True for `is_supported_type(model)` but the first one is picked instead of the second one [here](https://github.com/litestar-org/polyfactory/blob/main/polyfactory/factories/base.py#L292-L294).~

EDIT: fixed at c830ed5e0fadc5d3dc1d9461f7ac59428df74a9e

### Close Issue(s)

Fixes #192
