### PR TITLE
Fix: Random union types for dict

### DIFF
--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-
-from random import choice
 from typing import Any, get_args
 
 from polyfactory.utils.predicates import (
@@ -31,7 +29,7 @@ def unwrap_union(annotation: Any) -> Any:
     :returns: A type annotation
     """
     while is_union(annotation):
-        annotation = choice(get_args(annotation))
+        annotation = get_args(annotation)[0]
     return annotation
 
 

--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+from random import choice
 from typing import Any, get_args
 
 from polyfactory.utils.predicates import (
@@ -29,7 +31,7 @@ def unwrap_union(annotation: Any) -> Any:
     :returns: A type annotation
     """
     while is_union(annotation):
-        annotation = get_args(annotation)[0]
+        annotation = choice(get_args(annotation))
     return annotation
 
 

--- a/polyfactory/value_generators/complex_types.py
+++ b/polyfactory/value_generators/complex_types.py
@@ -35,7 +35,13 @@ def handle_container_type(
     if isinstance(container, MutableMapping) or is_typeddict(container):
         key_type, value_type = unwrap_args(field_meta.annotation) or (str, str)
         key = handle_complex_type(field_meta=FieldMeta.from_type(annotation=key_type), factory=factory)
-        value = handle_complex_type(field_meta=FieldMeta.from_type(annotation=value_type), factory=factory)
+
+        if is_union(value_type) and field_meta.children and field_meta.children[0].children:
+            value_field_meta = factory.__random__.choice(field_meta.children[0].children)
+            value = handle_complex_type(field_meta=value_field_meta, factory=factory)
+        else:
+            value = handle_complex_type(field_meta=FieldMeta.from_type(annotation=value_type), factory=factory)
+
         container[key] = value  # pyright: ignore
     elif field_meta.children:
         if isinstance(container, (list, deque)):

--- a/polyfactory/value_generators/complex_types.py
+++ b/polyfactory/value_generators/complex_types.py
@@ -36,8 +36,8 @@ def handle_container_type(
         key_type, value_type = unwrap_args(field_meta.annotation) or (str, str)
         key = handle_complex_type(field_meta=FieldMeta.from_type(annotation=key_type), factory=factory)
 
-        if is_union(value_type) and field_meta.children and field_meta.children[0].children:
-            value_field_meta = factory.__random__.choice(field_meta.children[0].children)
+        if is_union(value_type) and field_meta.children:
+            value_field_meta = factory.__random__.choice(field_meta.children)
             value = handle_complex_type(field_meta=value_field_meta, factory=factory)
         else:
             value = handle_complex_type(field_meta=FieldMeta.from_type(annotation=value_type), factory=factory)

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -21,8 +21,7 @@ def test_passing_nested_dict() -> None:
         my_mapping_obj={"baz": MyMappedClass(val="bar")},
     )
 
-    assert obj.dict() == {"my_mapping_obj": {"baz": {"val": "bar"}},
-                          "my_mapping_str": {"foo": "bar"}}
+    assert obj.dict() == {"my_mapping_obj": {"baz": {"val": "bar"}}, "my_mapping_str": {"foo": "bar"}}
 
 
 def test_dict_with_union_random_types() -> None:
@@ -36,13 +35,8 @@ def test_dict_with_union_random_types() -> None:
     str_generated = False
     for _ in range(20):
         obj = MyClassFactory.build()
-        int_generated = True if isinstance(
-            list(obj.val.values())[0], int
-        ) else int_generated
-        str_generated = True if isinstance(
-            list(obj.val.values())[0], str
-        ) else str_generated
-        print(obj)
+        int_generated = True if isinstance(list(obj.val.values())[0], int) else int_generated
+        str_generated = True if isinstance(list(obj.val.values())[0], str) else str_generated
 
     assert int_generated is True
     assert str_generated is True

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Union
 
 from pydantic import BaseModel
 
@@ -21,4 +21,28 @@ def test_passing_nested_dict() -> None:
         my_mapping_obj={"baz": MyMappedClass(val="bar")},
     )
 
-    assert obj.dict() == {"my_mapping_obj": {"baz": {"val": "bar"}}, "my_mapping_str": {"foo": "bar"}}
+    assert obj.dict() == {"my_mapping_obj": {"baz": {"val": "bar"}},
+                          "my_mapping_str": {"foo": "bar"}}
+
+
+def test_dict_with_union_random_types() -> None:
+    class MyClass(BaseModel):
+        val: Dict[str, Union[int, str]]
+
+    class MyClassFactory(ModelFactory[MyClass]):
+        __model__ = MyClass
+
+    int_generated = False
+    str_generated = False
+    for _ in range(20):
+        obj = MyClassFactory.build()
+        int_generated = True if isinstance(
+            list(obj.val.values())[0], int
+        ) else int_generated
+        str_generated = True if isinstance(
+            list(obj.val.values())[0], str
+        ) else str_generated
+        print(obj)
+
+    assert int_generated is True
+    assert str_generated is True

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -31,12 +31,10 @@ def test_dict_with_union_random_types() -> None:
     class MyClassFactory(ModelFactory[MyClass]):
         __model__ = MyClass
 
-    int_generated = False
-    str_generated = False
-    for _ in range(20):
-        obj = MyClassFactory.build()
-        int_generated = True if isinstance(list(obj.val.values())[0], int) else int_generated
-        str_generated = True if isinstance(list(obj.val.values())[0], str) else str_generated
+    MyClassFactory.seed_random(2)
 
-    assert int_generated is True
-    assert str_generated is True
+    test_obj_1 = MyClassFactory.build()
+    test_obj_2 = MyClassFactory.build()
+
+    assert isinstance(list(test_obj_1.val.values())[0], int)
+    assert isinstance(list(test_obj_2.val.values())[0], str)


### PR DESCRIPTION
## Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

## Description

Previously under pydantic-factory
values for a dictionary of union
were generated randomly based on
union types. Under the latest
version of polyfactory always the
first type is used. After that fix
everything is working like previously.

Test for that issue was added.