### PR TITLE
Misc. fixes for complex types 

### DIFF
--- a/docs/examples/fields/test_example_7.py
+++ b/docs/examples/fields/test_example_7.py
@@ -25,4 +25,4 @@ class DatetimeRangeFactory(DataclassFactory[DatetimeRange]):
 
 def test_post_generated() -> None:
     date_range_instance = DatetimeRangeFactory.build()
-    assert date_range_instance.to_dt.day == date_range_instance.from_dt.day + 1
+    assert date_range_instance.to_dt == date_range_instance.from_dt + timedelta(days=1)

--- a/polyfactory/value_generators/complex_types.py
+++ b/polyfactory/value_generators/complex_types.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING, AbstractSet, Any, MutableMapping, MutableSeque
 
 from typing_extensions import is_typeddict
 
-from polyfactory.field_meta import FieldMeta
-from polyfactory.utils.helpers import unwrap_annotation, unwrap_args
+from polyfactory.utils.helpers import unwrap_annotation
 from polyfactory.utils.predicates import get_type_origin, is_any, is_union
 from polyfactory.value_generators.primitives import create_random_string
 
 if TYPE_CHECKING:
     from polyfactory.factories.base import BaseFactory
+    from polyfactory.field_meta import FieldMeta
 
 
 def handle_collection_type(field_meta: FieldMeta, container_type: type, factory: type[BaseFactory]) -> Any:
@@ -27,13 +27,8 @@ def handle_collection_type(field_meta: FieldMeta, container_type: type, factory:
         return container
 
     if issubclass(container_type, MutableMapping) or is_typeddict(container_type):
-        key_type, value_type = unwrap_args(field_meta.annotation) or (str, str)
-        key = handle_complex_type(FieldMeta.from_type(key_type), factory)
-        if is_union(value_type) and field_meta.children:
-            value_field_meta = factory.__random__.choice(field_meta.children)
-            value = handle_complex_type(value_field_meta, factory)
-        else:
-            value = handle_complex_type(FieldMeta.from_type(value_type), factory)
+        key = handle_complex_type(field_meta.children[0], factory)
+        value = handle_complex_type(field_meta.children[1], factory)
         container[key] = value
 
     elif issubclass(container_type, MutableSequence):

--- a/polyfactory/value_generators/complex_types.py
+++ b/polyfactory/value_generators/complex_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, AbstractSet, Any, MutableMapping, MutableSequence, Set, TypeVar
+from typing import TYPE_CHECKING, AbstractSet, Any, Collection, MutableMapping, MutableSequence, Set, TypeVar
 
 from typing_extensions import is_typeddict
 
@@ -59,7 +59,9 @@ def handle_complex_type(field_meta: FieldMeta, factory: type[BaseFactory]) -> An
     :returns: A built result.
     """
     if origin := get_type_origin(unwrap_annotation(field_meta.annotation)):
-        return handle_collection_type(field_meta, origin, factory)
+        if issubclass(origin, Collection):
+            return handle_collection_type(field_meta, origin, factory)
+        return factory.get_mock_value(origin)
 
     if is_union(field_meta.annotation) and field_meta.children:
         return handle_complex_type(factory.__random__.choice(field_meta.children), factory)

--- a/polyfactory/value_generators/complex_types.py
+++ b/polyfactory/value_generators/complex_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, AbstractSet, Any, MutableMapping, MutableSequence, Set
+from typing import TYPE_CHECKING, AbstractSet, Any, MutableMapping, MutableSequence, Set, TypeVar
 
 from typing_extensions import is_typeddict
 
@@ -69,7 +69,7 @@ def handle_complex_type(field_meta: FieldMeta, factory: type[BaseFactory]) -> An
     if is_union(field_meta.annotation) and field_meta.children:
         return handle_complex_type(factory.__random__.choice(field_meta.children), factory)
 
-    if is_any(field_meta.annotation):
+    if is_any(field_meta.annotation) or isinstance(field_meta.annotation, TypeVar):
         return create_random_string(factory.__random__, min_length=1, max_length=10)
 
     return factory.get_field_value(field_meta)

--- a/polyfactory/value_generators/complex_types.py
+++ b/polyfactory/value_generators/complex_types.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
-from collections import deque
-from typing import TYPE_CHECKING, Any, MutableMapping, Tuple
+
+from typing import TYPE_CHECKING, AbstractSet, Any, MutableMapping, MutableSequence, Set
 
 from typing_extensions import is_typeddict
 
-from polyfactory.constants import TYPE_MAPPING
 from polyfactory.field_meta import FieldMeta
 from polyfactory.utils.helpers import unwrap_annotation, unwrap_args
 from polyfactory.utils.predicates import get_type_origin, is_any, is_union
@@ -14,11 +13,7 @@ if TYPE_CHECKING:
     from polyfactory.factories.base import BaseFactory
 
 
-def handle_container_type(
-    container_type: type,
-    factory: type[BaseFactory],
-    field_meta: FieldMeta,
-) -> Any:
+def handle_collection_type(field_meta: FieldMeta, container_type: type, factory: type[BaseFactory]) -> Any:
     """Handle generation of container types recursively.
 
     :param container_type: A type that can accept type arguments.
@@ -27,68 +22,54 @@ def handle_container_type(
 
     :returns: A built result.
     """
-    if mapped_container_type := TYPE_MAPPING.get(container_type):
-        container_type = mapped_container_type
+    container = container_type()
+    if not field_meta.children:
+        return container
 
-    container = container_type() if container_type is not frozenset else set()
-
-    if isinstance(container, MutableMapping) or is_typeddict(container):
+    if issubclass(container_type, MutableMapping) or is_typeddict(container_type):
         key_type, value_type = unwrap_args(field_meta.annotation) or (str, str)
-        key = handle_complex_type(field_meta=FieldMeta.from_type(annotation=key_type), factory=factory)
-
+        key = handle_complex_type(FieldMeta.from_type(key_type), factory)
         if is_union(value_type) and field_meta.children:
             value_field_meta = factory.__random__.choice(field_meta.children)
-            value = handle_complex_type(field_meta=value_field_meta, factory=factory)
+            value = handle_complex_type(value_field_meta, factory)
         else:
-            value = handle_complex_type(field_meta=FieldMeta.from_type(annotation=value_type), factory=factory)
+            value = handle_complex_type(FieldMeta.from_type(value_type), factory)
+        container[key] = value
 
-        container[key] = value  # pyright: ignore
-    elif field_meta.children:
-        if isinstance(container, (list, deque)):
-            container.append(
-                handle_complex_type(
-                    field_meta=factory.__random__.choice(field_meta.children),
-                    factory=factory,
-                )
-            )
-        else:
-            container.add(
-                handle_complex_type(
-                    field_meta=factory.__random__.choice(field_meta.children),
-                    factory=factory,
-                )
-            )
+    elif issubclass(container_type, MutableSequence):
+        container.append(handle_complex_type(field_meta.children[0], factory))
 
-    return container if container_type is not frozenset else container_type(*container)
+    elif issubclass(container_type, Set):
+        container.add(handle_complex_type(field_meta.children[0], factory))
+
+    elif issubclass(container_type, AbstractSet):
+        container = container.union(handle_collection_type(field_meta, set, factory))
+
+    elif issubclass(container_type, tuple):
+        container = container_type(handle_complex_type(subfield_meta, factory) for subfield_meta in field_meta.children)
+
+    else:
+        raise NotImplementedError(f"Unsupported container type: {container_type}")
+
+    return container
 
 
-def handle_complex_type(
-    factory: type[BaseFactory],
-    field_meta: FieldMeta,
-) -> Any:
-    """Recursive type generation based on typing info stored in the graph like structure of pydantic field_metas.
+def handle_complex_type(field_meta: FieldMeta, factory: type[BaseFactory]) -> Any:
+    """Recursive type generation based on typing info stored in the graph like structure
+    of pydantic field_metas.
 
-    :param factory: A factory.
     :param field_meta: A field meta instance.
+    :param factory: A factory.
 
     :returns: A built result.
     """
-
-    if origin := get_type_origin(annotation=unwrap_annotation(field_meta.annotation)):
-        if origin not in (tuple, Tuple):
-            return handle_container_type(field_meta=field_meta, container_type=origin, factory=factory)
-
-        return tuple(
-            handle_complex_type(field_meta=sub_field, factory=factory) for sub_field in (field_meta.children or [])
-        )
+    if origin := get_type_origin(unwrap_annotation(field_meta.annotation)):
+        return handle_collection_type(field_meta, origin, factory)
 
     if is_union(field_meta.annotation) and field_meta.children:
-        return handle_complex_type(field_meta=factory.__random__.choice(field_meta.children), factory=factory)
+        return handle_complex_type(factory.__random__.choice(field_meta.children), factory)
 
     if is_any(field_meta.annotation):
-        return create_random_string(random=factory.__random__, min_length=1, max_length=10)
+        return create_random_string(factory.__random__, min_length=1, max_length=10)
 
-    if factory.should_set_none_value(field_meta):
-        return None
-
-    return factory.get_field_value(field_meta=field_meta, field_build_parameters=None)
+    return factory.get_field_value(field_meta)

--- a/tests/test_complex_types.py
+++ b/tests/test_complex_types.py
@@ -35,6 +35,9 @@ def test_handles_complex_typing() -> None:
         deque: Deque[List[Dict[str, int]]]
         set_union: Set[Union[str, int]]
         frozen_set: FrozenSet[str]
+        plain_list: List
+        plain_set: Set
+        plain_dict: Dict
 
     class MyFactory(ModelFactory):
         __model__ = MyModel
@@ -51,6 +54,9 @@ def test_handles_complex_typing() -> None:
     assert result.deque
     assert result.set_union
     assert result.frozen_set
+    assert result.plain_list
+    assert result.plain_set
+    assert result.plain_dict
 
 
 def test_handles_complex_typing_with_embedded_models() -> None:

--- a/tests/test_constrained_attribute_parsing.py
+++ b/tests/test_constrained_attribute_parsing.py
@@ -136,6 +136,12 @@ def test_nested_constrained_attribute_handling() -> None:
         my_int_list_field: List[MyConstrainedInt]
         my_str_list_field: List[MyConstrainedString]
 
+        my_bytes_dict_field: Dict[str, MyConstrainedBytes]
+        my_decimal_dict_field: Dict[str, MyConstrainedDecimal]
+        my_float_dict_field: Dict[str, MyConstrainedFloat]
+        my_int_dict_field: Dict[str, MyConstrainedInt]
+        my_str_dict_field: Dict[str, MyConstrainedString]
+
     class MyFactory(ModelFactory):
         __model__ = MyModel
 
@@ -154,3 +160,9 @@ def test_nested_constrained_attribute_handling() -> None:
     assert result.my_float_list_field
     assert result.my_int_list_field
     assert result.my_str_list_field
+
+    assert result.my_bytes_dict_field
+    assert result.my_decimal_dict_field
+    assert result.my_float_dict_field
+    assert result.my_int_dict_field
+    assert result.my_str_dict_field

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -31,7 +31,7 @@ def test_dict_with_union_random_types() -> None:
     class MyClassFactory(ModelFactory[MyClass]):
         __model__ = MyClass
 
-    MyClassFactory.seed_random(2)
+    MyClassFactory.seed_random(4)
 
     test_obj_1 = MyClassFactory.build()
     test_obj_2 = MyClassFactory.build()


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description

Several fixes related to complex types + overall refactoring of `complex_types.py` while at it.

1. [Fix](https://github.com/litestar-org/polyfactory/pull/202/commits/43553879e2a45d9c5d998f82d3f7eb0afe9b9b24) for generic container fields with unspecified type parameters, e.g. `List` instead of `List[Any]`. 
   Currently raises `ParameterException: Unsupported type: ~T`
2. [Fix](https://github.com/litestar-org/polyfactory/pull/202/commits/1d1c721e64e0ca4ec10afd612e37eb2406324628) for Pydantic constrained mapping fields, e.g. `Dict[str, MyConstrainedInt]`.
    Currently the factory ignores the constraint, resulting in ValidationError.
3. [Fix](https://github.com/litestar-org/polyfactory/pull/202/commits/caf7e0b16b88fabca26dbb41aa405a703e8e69b8) for custom generic fields that are not collections; should be handled by `get_mock_value`.
    Currently raises `AttributeError: ..  object has no attribute 'add'`

EDIT: 
4. [Fix](https://github.com/litestar-org/polyfactory/pull/202/commits/7c4b352a799ad146b49b4a89db8bce3affcc4a24) an unrelated test.