### PR TITLE
Don't ignore the id field of odmantic models

### DIFF
--- a/polyfactory/factories/odmantic_odm_factory.py
+++ b/polyfactory/factories/odmantic_odm_factory.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, Union
 
 from polyfactory.exceptions import MissingDependencyException
 from polyfactory.factories.pydantic_factory import ModelFactory
-from polyfactory.fields import Ignore
 from polyfactory.utils.predicates import is_safe_subclass
 from polyfactory.value_generators.primitives import create_random_bytes
 
@@ -35,8 +34,6 @@ class OdmanticModelFactory(Generic[T], ModelFactory[T]):
         :returns: A typeguard
         """
         return is_safe_subclass(value, Model) or is_safe_subclass(value, EmbeddedModel)
-
-    id = Ignore()
 
     @classmethod
     def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:

--- a/tests/test_odmantic_factory.py
+++ b/tests/test_odmantic_factory.py
@@ -4,8 +4,10 @@ from uuid import UUID
 
 import bson
 import pytest
+from bson import ObjectId
 from odmantic import AIOEngine, EmbeddedModel, Model
 
+from polyfactory.decorators import post_generated
 from polyfactory.factories.odmantic_odm_factory import OdmanticModelFactory
 
 
@@ -52,6 +54,8 @@ def test_handles_odmantic_models() -> None:
 
     result = MyFactory.build()
 
+    assert isinstance(result, MyModel)
+    assert isinstance(result.id, bson.ObjectId)
     assert isinstance(result.created_on, datetime)
     assert isinstance(result.bson_id, bson.ObjectId)
     assert isinstance(result.bson_int64, bson.Int64)
@@ -79,3 +83,15 @@ def test_handles_odmantic_models() -> None:
         assert isinstance(other.bson_int64, bson.Int64)
         assert isinstance(other.bson_dec128, bson.Decimal128)
         assert isinstance(other.bson_binary, bson.Binary)
+
+
+def test_post_generated_from_id() -> None:
+    class MyFactory(OdmanticModelFactory):
+        __model__ = MyModel
+
+        @post_generated
+        @classmethod
+        def name(cls, id: ObjectId) -> str:
+            return f"{cls.__faker__.name()} [{id.generation_time}]"
+
+    MyFactory.build()


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage

### Description

The `id` field of Odmantic models doesn't have to be specified as `Ignore`; its type is `bson.ObjectId` which has a default constructor so it can be autogenerated. By not ignoring it, it can be used as a dependency of `PostGenerated` fields as shown in the unit test.