### PR TITLE
Add support for custom root types in Pydantic model factory

### DIFF
--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -169,3 +169,29 @@ class ModelFactory(Generic[T], BaseFactory[T]):
             return cls.__model__.construct(**processed_kwargs)
 
         return cls.__model__(**processed_kwargs)
+
+    @classmethod
+    def is_custom_root_field(cls, field_meta: FieldMeta) -> bool:
+        """Determine whether the field is a custom root field.
+
+        :param field_meta: FieldMeta instance.
+
+        :returns: A boolean determining whether the field is a custom root.
+
+        """
+        return field_meta.name == "__root__"
+
+    @classmethod
+    def should_set_field_value(cls, field_meta: FieldMeta, **kwargs: Any) -> bool:
+        """Determine whether to set a value for a given field_name.
+        This is an override of BaseFactory.should_set_field_value.
+
+        :param field_meta: FieldMeta instance.
+        :param kwargs: Any kwargs passed to the factory.
+
+        :returns: A boolean determining whether a value should be set for the given field_meta.
+
+        """
+        return field_meta.name not in kwargs and (
+            not field_meta.name.startswith("_") or cls.is_custom_root_field(field_meta)
+        )

--- a/tests/test_complex_types.py
+++ b/tests/test_complex_types.py
@@ -78,6 +78,19 @@ def test_handles_complex_typing_with_embedded_models() -> None:
     assert result.person_list[0].pets
 
 
+def test_handles_complex_typing_with_custom_root_type() -> None:
+    class MyModel(BaseModel):
+        __root__: List[int]
+
+    class MyFactory(ModelFactory[MyModel]):
+        __model__ = MyModel
+
+    result = MyFactory.build()
+
+    assert result.__root__
+    assert isinstance(result.__root__, list)
+
+
 def test_raises_for_user_defined_types() -> None:
     class MyClass:
         def __init__(self, value: int):


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md) for this repository."

- [X] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

Add support for https://docs.pydantic.dev/latest/usage/models/#custom-root-types, a Pydantic feature which allows for things such as root-level discriminated unions. This is achieved by specifying a "dummy" field called `__root__` which was considered private/non-injectable by Polyfactory so far. (I recall it working in the latest `pydantic-factories` though :) )

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
