### PR TITLE
Retrieve field types from result of `get_type_hints()`.

### DIFF
--- a/polyfactory/factories/dataclass_factory.py
+++ b/polyfactory/factories/dataclass_factory.py
@@ -3,6 +3,7 @@ from dataclasses import is_dataclass, fields, MISSING
 from inspect import isclass
 from typing import Generic, Any, TYPE_CHECKING
 
+from typing_extensions import get_type_hints
 
 from polyfactory.factories.base import T, BaseFactory
 from polyfactory.field_meta import FieldMeta, Null
@@ -39,6 +40,8 @@ class DataclassFactory(Generic[T], BaseFactory[T]):
         """
         fields_meta: list["FieldMeta"] = []
 
+        model_type_hints = get_type_hints(cls.__model__)
+
         for field in fields(cls.__model__):  # type: ignore[arg-type]
             if field.default_factory and field.default_factory is not MISSING:
                 default_value = field.default_factory()
@@ -47,6 +50,8 @@ class DataclassFactory(Generic[T], BaseFactory[T]):
             else:
                 default_value = Null
 
-            fields_meta.append(FieldMeta.from_type(annotation=field.type, name=field.name, default=default_value))
+            fields_meta.append(
+                FieldMeta.from_type(annotation=model_type_hints[field.name], name=field.name, default=default_value)
+            )
 
         return fields_meta

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib.util
+import random
+import string
+import sys
+
+from typing import TYPE_CHECKING, TypeVar
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from types import ModuleType
+    from typing import Callable
+
+    from pytest import MonkeyPatch
+
+
+T = TypeVar("T")
+
+
+@pytest.fixture
+def create_module(tmp_path: Path, monkeypatch: MonkeyPatch) -> Callable[[str], ModuleType]:
+    """Utility fixture for dynamic module creation."""
+
+    def wrapped(source: str) -> ModuleType:
+        """
+
+        Args:
+            source: Source code as a string.
+
+        Returns:
+            An imported module.
+        """
+
+        def not_none(val: T | None) -> T:
+            assert val is not None
+            return val
+
+        def module_name_generator() -> str:
+            letters = string.ascii_lowercase
+            return "".join(random.choice(letters) for _ in range(10))
+
+        module_name = module_name_generator()
+        path = tmp_path / f"{module_name}.py"
+        path.write_text(source)
+        # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+        spec = not_none(importlib.util.spec_from_file_location(module_name, path))
+        module = not_none(importlib.util.module_from_spec(spec))
+        monkeypatch.setitem(sys.modules, module_name, module)
+        not_none(spec.loader).exec_module(module)
+        return module
+
+    return wrapped


### PR DESCRIPTION
Fixes issue where factory produced from model with forward ref annotations raises `ParameterException` due to annotation being a string.

Closes #228

[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
