### PR TITLE
Fix list of literal generation (#239)

### DIFF
--- a/tests/test_complex_types.py
+++ b/tests/test_complex_types.py
@@ -33,6 +33,7 @@ def test_handles_complex_typing() -> None:
         nested_dict: Dict[str, Dict[Union[int, str], Dict[Any, List[Dict[str, str]]]]]
         dict_str_any: Dict[str, Any]
         nested_list: List[List[List[Dict[str, List[Any]]]]]
+        sequence_literal: Sequence[Literal[1, 2, 3]]
         sequence_dict: Sequence[Dict]
         iterable_float: Iterable[float]
         tuple_ellipsis: Tuple[int, ...]


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
The issue described in #239 is fixed in this PR. The issue arises, because the generation of Literal field is handled directly in `polyfactory.factories.base.BaseFactory.get_field_value()`, but generating for a collection type uses `polyfactory.value_generators.complex_types.handle_complex_type()`.

The fix adds the handling for literals to that function, but this creates a bit of code duplication. The better way would probably be to move the code for handling literals into a separate function, but I don't know the code structure well enough, so I'm open to suggestions.

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
Closes #239