### PR TITLE
Drop `__set_as_default_factory_for_type__`

### DIFF
--- a/docs/examples/configuration/test_example_5.py
+++ b/docs/examples/configuration/test_example_5.py
@@ -33,13 +33,13 @@ class Person:
 
 class PetFactory(DataclassFactory[Pet]):
     __model__ = Pet
-    __set_as_default_factory_for_type__ = True
 
     name = Use(DataclassFactory.__random__.choice, ["Roxy", "Spammy", "Moshe"])
 
 
 class PersonFactory(DataclassFactory[Person]):
     __model__ = Person
+    __base_factory_overrides__ = {Pet: PetFactory}
 
 
 def test_default_pet_factory() -> None:

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -197,11 +197,6 @@ class BaseFactory(ABC, Generic[T]):
     """A sync persistence handler. Can be a class or a class instance."""
     __async_persistence__: type[AsyncPersistenceProtocol[T]] | AsyncPersistenceProtocol[T] | None = None
     """An async persistence handler. Can be a class or a class instance."""
-    __set_as_default_factory_for_type__ = False
-    """
-    Flag dictating whether to set as the default factory for the given type.
-    If 'True' the factory will be used instead of dynamically generating a factory for the type.
-    """
     __is_base_factory__: bool = False
     """
     Flag dictating whether the factory is a 'base' factory. Base factories are registered globally as handlers for types.
@@ -230,7 +225,6 @@ class BaseFactory(ABC, Generic[T]):
     # cached attributes
     _fields_metadata: list[FieldMeta]
     # BaseFactory only attributes
-    _factory_type_mapping: ClassVar[dict[Any, type[BaseFactory[Any]]]]
     _base_factories: ClassVar[list[type[BaseFactory[Any]]]]
 
     def __init_subclass__(cls, *args: Any, **kwargs: Any) -> None:
@@ -238,9 +232,6 @@ class BaseFactory(ABC, Generic[T]):
 
         if not hasattr(BaseFactory, "_base_factories"):
             BaseFactory._base_factories = []
-
-        if not hasattr(BaseFactory, "_factory_type_mapping"):
-            BaseFactory._factory_type_mapping = {}
 
         if "__is_base_factory__" not in cls.__dict__ or not cls.__is_base_factory__:
             model = getattr(cls, "__model__", None)
@@ -264,9 +255,6 @@ class BaseFactory(ABC, Generic[T]):
 
         if random_seed := getattr(cls, "__random_seed__", None) is not None:
             cls.seed_random(random_seed)
-
-        if cls.__set_as_default_factory_for_type__:
-            BaseFactory._factory_type_mapping[cls.__model__] = cls
 
     @classmethod
     def _get_sync_persistence(cls) -> SyncPersistenceProtocol[T]:
@@ -328,13 +316,10 @@ class BaseFactory(ABC, Generic[T]):
         :returns: A Factory sub-class.
 
         """
-        if factory := BaseFactory._factory_type_mapping.get(model):
-            return factory
-
         if cls.__base_factory_overrides__:
             for model_ancestor in model.mro():
                 if factory := cls.__base_factory_overrides__.get(model_ancestor):
-                    return factory.create_factory(model)
+                    return factory if hasattr(factory, "__model__") else factory.create_factory(model)
 
         for factory in reversed(BaseFactory._base_factories):
             if factory.is_supported_type(model):

--- a/tests/test_setting_default_factories.py
+++ b/tests/test_setting_default_factories.py
@@ -30,10 +30,10 @@ def test_auto_register_model_factory() -> None:
     class BFactory(ModelFactory):
         b_text = "const value"
         __model__ = B
-        __set_as_default_factory_for_type__ = True
 
     class CFactory(ModelFactory):
         __model__ = C
+        __base_factory_overrides__ = {B: BFactory}
 
     c = CFactory.build()
 
@@ -45,8 +45,8 @@ def test_auto_register_model_factory() -> None:
 def test_auto_register_model_factory_using_create_factory() -> None:
     const_value = "const value"
     ModelFactory.create_factory(model=A, a_text=const_value)
-    ModelFactory.create_factory(model=B, b_text=const_value, __set_as_default_factory_for_type__=True)
-    factory = ModelFactory.create_factory(model=C)
+    BFactory = ModelFactory.create_factory(model=B, b_text=const_value)
+    factory = ModelFactory.create_factory(model=C, __base_factory_overrides__={B: BFactory})
 
     c = factory.build()
 
@@ -64,13 +64,13 @@ def test_dataclass_model_factory_auto_registration() -> None:
         nested_field: DataClass
         nested_list_field: List[DataClass]
 
-    class UpperModelFactory(ModelFactory):
-        __model__ = UpperModel
-
     class DTFactory(DataclassFactory):
         text = "const value"
         __model__ = DataClass
-        __set_as_default_factory_for_type__ = True
+
+    class UpperModelFactory(ModelFactory):
+        __model__ = UpperModel
+        __base_factory_overrides__ = {DataClass: DTFactory}
 
     upper = UpperModelFactory.build()
 
@@ -86,13 +86,13 @@ def test_typeddict_model_factory_auto_registration() -> None:
         nested_field: TD
         nested_list_field: List[TD]
 
-    class UpperModelFactory(ModelFactory):
-        __model__ = UpperSchema
-
     class TDFactory(TypedDictFactory):
         text = "const value"
         __model__ = TD
-        __set_as_default_factory_for_type__ = True
+
+    class UpperModelFactory(ModelFactory):
+        __model__ = UpperSchema
+        __base_factory_overrides__ = {TD: TDFactory}
 
     upper = UpperModelFactory.build()
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage

### Description

Drop `BaseFactory.__set_as_default_factory_for_type__` and associated `_factory_type_mapping` without loss of functionality: the newly introduced `__base_factory_overrides__` subsumes it.

- Pros: One global state attribute less
- Cons: Backwards incompatible change