### PR TITLE
Use is_safe_subclass consistently

### DIFF
--- a/polyfactory/factories/dataclass_factory.py
+++ b/polyfactory/factories/dataclass_factory.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import MISSING, fields, is_dataclass
-from inspect import isclass
-from typing import TYPE_CHECKING, Any, Generic
+from typing import Any, Generic
 
-from typing_extensions import get_type_hints
+from typing_extensions import TypeGuard, get_type_hints
 
 from polyfactory.factories.base import BaseFactory, T
 from polyfactory.field_meta import FieldMeta, Null
-
-if TYPE_CHECKING:
-    from typing_extensions import TypeGuard
 
 
 class DataclassFactory(Generic[T], BaseFactory[T]):
@@ -19,16 +15,13 @@ class DataclassFactory(Generic[T], BaseFactory[T]):
     __is_base_factory__ = True
 
     @classmethod
-    def is_supported_type(cls, value: Any) -> "TypeGuard[type[T]]":
+    def is_supported_type(cls, value: Any) -> TypeGuard[type[T]]:
         """Determine whether the given value is supported by the factory.
 
         :param value: An arbitrary value.
         :returns: A typeguard
         """
-        try:
-            return isclass(value) and is_dataclass(value)
-        except (TypeError, AttributeError):  # pragma: no cover
-            return False
+        return bool(is_dataclass(value))
 
     @classmethod
     def get_model_fields(cls) -> list["FieldMeta"]:

--- a/polyfactory/factories/odmantic_odm_factory.py
+++ b/polyfactory/factories/odmantic_odm_factory.py
@@ -34,7 +34,7 @@ class OdmanticModelFactory(Generic[T], ModelFactory[T]):
         :param value: An arbitrary value.
         :returns: A typeguard
         """
-        return is_safe_subclass(value, Model) or is_safe_subclass(value, EmbeddedModel)
+        return is_safe_subclass(value, (Model, EmbeddedModel))
 
     @classmethod
     def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:

--- a/polyfactory/factories/typed_dict_factory.py
+++ b/polyfactory/factories/typed_dict_factory.py
@@ -16,16 +16,13 @@ class TypedDictFactory(Generic[TypedDictT], BaseFactory[TypedDictT]):
     __is_base_factory__ = True
 
     @classmethod
-    def is_supported_type(cls, value: Any) -> "TypeGuard[type[TypedDictT]]":
+    def is_supported_type(cls, value: Any) -> TypeGuard[type[TypedDictT]]:
         """Determine whether the given value is supported by the factory.
 
         :param value: An arbitrary value.
         :returns: A typeguard
         """
-        try:
-            return is_typeddict(value)
-        except (TypeError, AttributeError):  # pragma: no cover
-            return False
+        return is_typeddict(value)
 
     @classmethod
     def get_model_fields(cls) -> list["FieldMeta"]:

--- a/polyfactory/pytest_plugin.py
+++ b/polyfactory/pytest_plugin.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -10,19 +9,15 @@ from typing import (
     Union,
 )
 
-from pytest import fixture
+from pytest import Config, fixture
 
 from polyfactory.exceptions import ParameterException
-
-if TYPE_CHECKING:
-    from pytest import Config  # nopycln: import
-
-    from polyfactory.factories.base import BaseFactory
-
+from polyfactory.factories.base import BaseFactory
+from polyfactory.utils.predicates import is_safe_subclass
 
 Scope = Union[
     Literal["session", "package", "module", "class", "function"],
-    Callable[[str, "Config"], Literal["session", "package", "module", "class", "function"]],
+    Callable[[str, Config], Literal["session", "package", "module", "class", "function"]],
 ]
 
 
@@ -68,9 +63,7 @@ class FactoryFixture:
         self.name = name
 
     def __call__(self, factory: type[BaseFactory[Any]]) -> Any:
-        from polyfactory.factories.base import is_factory
-
-        if not is_factory(factory):
+        if not is_safe_subclass(factory, BaseFactory):
             raise ParameterException(f"{factory.__name__} is not a BaseFactory subclass.")
 
         fixture_name = self.name or _get_fixture_name(factory.__name__)

--- a/polyfactory/utils/predicates.py
+++ b/polyfactory/utils/predicates.py
@@ -28,11 +28,11 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
-def is_safe_subclass(annotation: Any, super_class: type[T]) -> "TypeGuard[type[T]]":
+def is_safe_subclass(annotation: Any, class_or_tuple: type[T] | tuple[type[T], ...]) -> "TypeGuard[type[T]]":
     """Determine whether a given annotation is a subclass of a give type
 
     :param annotation: A type annotation.
-    :param super_class: A potential super class.
+    :param class_or_tuple: A potential super class or classes.
 
     :returns: A typeguard
     """
@@ -40,7 +40,7 @@ def is_safe_subclass(annotation: Any, super_class: type[T]) -> "TypeGuard[type[T
     if not origin and not isclass(annotation):
         return False
     try:
-        return issubclass(origin or annotation, super_class)
+        return issubclass(origin or annotation, class_or_tuple)
     except TypeError:  # pragma: no cover
         return False
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] New code has 100% test coverage

### Description

- Extend `utils.predicates.is_safe_subclass` to accept tuple of classes just like regular `issubclass`
- Replace all `isclass(...) and issubclass(...)` expressions with `is_safe_subclass` 