### PR TITLE
`using_base_factories` context manager

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -481,14 +481,7 @@ class BaseFactory(ABC, Generic[T]):
         :returns: A 'ModelFactory' subclass.
 
         """
-        return cast(
-            type[BaseFactory[Any]],
-            type(
-                f"{model.__name__}Factory",
-                (*(bases or ()), cls),
-                {"__model__": model, **kwargs},
-            ),
-        )
+        return type(f"{model.__name__}Factory", (*(bases or ()), cls), {"__model__": model, **kwargs})
 
     @classmethod
     def get_constrained_field_value(cls, annotation: Any, field_meta: FieldMeta) -> Any:

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -196,12 +196,6 @@ class BaseFactory(ABC, Generic[T]):
     Flag dictating whether the factory is a 'base' factory. Base factories are registered globally as handlers for types.
     For example, the 'DataclassFactory', 'TypedDictFactory' and 'ModelFactory' are all base factories.
     """
-    __base_factory_overrides__: dict[Any, type[BaseFactory[Any]]] | None = None
-    """
-    A base factory to override with this factory. If this value is set, the given factory will replace the given base factory.
-
-    Note: this value can only be set when '__is_base_factory__' is 'True'.
-    """
     __faker__: ClassVar["Faker"] = Faker()
     """
     A faker instance to use. Can be a user provided value.
@@ -326,11 +320,6 @@ class BaseFactory(ABC, Generic[T]):
         """
         if factory := cls._factory_type_mapping.get(model):
             return factory
-
-        if cls.__base_factory_overrides__:
-            for model_ancestor in model.mro():
-                if factory := cls.__base_factory_overrides__.get(model_ancestor):
-                    return factory.create_factory(model)
 
         for factory in reversed(cls._base_factories):
             if factory.is_supported_type(model):

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -246,7 +246,7 @@ class BaseFactory(ABC, Generic[T]):
 
     @classmethod
     @contextmanager
-    def using_base_factories(cls, *factories: type[BaseFactory]) -> Iterator[None]:
+    def using_base_factories(cls, *factories: type[BaseFactory[Any]]) -> Iterator[None]:
         """Context manager to temporarily add base factories to the list of base factories.
 
         :param factories: One or more base factories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ select = [
 ignore = [
     "A003", # flake8-builtins - class attribute {name} is shadowing a python builtin
     "B010", # flake8-bugbear - do not call setattr with a constant attribute value
+    "S101", # flake8-bandit - use of assert detected
     "D100", # pydocstyle - missing docstring in public module
     "D101", # pydocstyle - missing docstring in public class
     "D102", # pydocstyle - missing docstring in public method

--- a/tests/test_base_factories.py
+++ b/tests/test_base_factories.py
@@ -34,13 +34,12 @@ def test_multiple_base_factories() -> None:
 
     class MyFactory(FooDataclassFactory):
         __model__ = MyModel
-        __base_factory_overrides__ = {MyModelWithFoo: FooDataclassFactory}
 
-    MyFactory.build()
+    with MyFactory.using_base_factories(FooDataclassFactory):
+        MyFactory.build()
 
 
-@pytest.mark.parametrize("override_BaseModel", [False, True])
-def test_multiple_base_pydantic_factories(override_BaseModel: bool) -> None:
+def test_multiple_base_pydantic_factories() -> None:
     class Foo:
         def __init__(self, value: str) -> None:
             self.value = value
@@ -66,12 +65,9 @@ def test_multiple_base_pydantic_factories(override_BaseModel: bool) -> None:
 
     class MyFactory(FooModelFactory):
         __model__ = MyModel
-        if override_BaseModel:
-            __base_factory_overrides__ = {BaseModel: FooModelFactory}
-        else:
-            __base_factory_overrides__ = {MyModelWithFoo: FooModelFactory}
 
-    MyFactory.build()
+    with MyFactory.using_base_factories(FooModelFactory):
+        MyFactory.build()
 
 
 def test_using_base_factories() -> None:

--- a/tests/test_base_factories.py
+++ b/tests/test_base_factories.py
@@ -24,7 +24,6 @@ def test_multiple_base_factories() -> None:
         def get_provider_map(cls) -> Dict[Any, Any]:
             return {Foo: lambda: Foo("foo"), **super().get_provider_map()}
 
-    # noinspection PyUnusedLocal
     class DummyDataclassFactory(DataclassFactory):
         __is_base_factory__ = True
 
@@ -58,7 +57,6 @@ def test_multiple_base_pydantic_factories(override_BaseModel: bool) -> None:
         def get_provider_map(cls) -> Dict[Any, Any]:
             return {Foo: lambda: Foo("foo"), **super().get_provider_map()}
 
-    # noinspection PyUnusedLocal
     class DummyModelFactory(ModelFactory):
         __is_base_factory__ = True
 
@@ -78,3 +76,29 @@ def test_multiple_base_pydantic_factories(override_BaseModel: bool) -> None:
     # see https://github.com/litestar-org/polyfactory/issues/198
     ModelFactory._base_factories.remove(FooModelFactory)
     ModelFactory._base_factories.remove(DummyModelFactory)
+
+
+def test_implicit_custom_base_factory() -> None:
+    class Foo:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    class FooDataclassFactory(DataclassFactory):
+        __is_base_factory__ = True
+
+        @classmethod
+        def get_provider_map(cls) -> Dict[Any, Any]:
+            return {Foo: lambda: Foo("foo"), **super().get_provider_map()}
+
+    @dataclass
+    class MyModelWithFoo:
+        foo: Foo
+
+    @dataclass
+    class MyModel:
+        nested: MyModelWithFoo
+
+    class MyFactory(DataclassFactory):
+        __model__ = MyModel
+
+    MyFactory.build()

--- a/tests/test_factory_subclassing.py
+++ b/tests/test_factory_subclassing.py
@@ -71,7 +71,3 @@ def test_inherit_base_factory() -> None:
     exc_info = pytest.raises(AttributeError, ParentFactory.build)
     assert "'ParentFactory' has no attribute '__model__'" in str(exc_info.value)
     assert ChildFactory.build().name == "Child"
-
-    # remove the ParentFactory from _base_factories to prevent side effects in other tests
-    # see https://github.com/litestar-org/polyfactory/issues/198
-    ModelFactory._base_factories.remove(ParentFactory)


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Litestar contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

### Description

Introduce a new `BaseFactory.using_base_factories(*factories)` context manager to _temporarily_ add one or more base factories in the the enclosed scope. Once the scope exits, the base factories are removed. 

The context manager replaces the implicit registration of custom base factories. However the "builtin" polyfactory base factories (`DataclassFactory`, `ModelFactory`, `MsgspecFactory`, etc) are still registered implicitly at import time.

In addition to limiting the global state mutation scope, the `using_base_factories` context manager removes the need for `__base_factory_overrides__`, which is dropped [here](https://github.com/litestar-org/polyfactory/commit/9e8dbbf28d30be6c58cc1ee0d14b9acf40d23904).