### PR TITLE
Fix `const` not being used with pydantic v1 models. 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,6 +86,7 @@ nitpick_ignore = [
     (PY_CLASS, "tzinfo"),
     (PY_CLASS, "BeanieDocumentFactory"),
     (PY_CLASS, "OdmanticModelFactory"),
+    (PY_CLASS, "ModelField"),
 ]
 nitpick_ignore_regex = [
     (PY_RE, r"typing_extensions.*"),

--- a/poetry.lock
+++ b/poetry.lock
@@ -779,10 +779,10 @@ files = []
 develop = false
 
 [package.extras]
-dev = ["attrs", "coverage", "furo", "gcovr", "ipython", "msgpack", "mypy", "pre-commit", "pyright", "pytest", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "tomli", "tomli-w"]
+dev = ["attrs", "coverage", "furo", "gcovr", "ipython", "msgpack", "mypy", "pre-commit", "pyright", "pytest", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "tomli", "tomli_w"]
 doc = ["furo", "ipython", "sphinx", "sphinx-copybutton", "sphinx-design"]
-test = ["attrs", "msgpack", "mypy", "pyright", "pytest", "pyyaml", "tomli", "tomli-w"]
-toml = ["tomli", "tomli-w"]
+test = ["attrs", "msgpack", "mypy", "pyright", "pytest", "pyyaml", "tomli", "tomli_w"]
+toml = ["tomli", "tomli_w"]
 yaml = ["pyyaml"]
 
 [package.source]

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -610,9 +610,6 @@ class BaseFactory(ABC, Generic[T]):
         if cls.is_ignored_type(field_meta.annotation):
             return None
 
-        if field_meta.constraints and field_meta.constraints.pop("constant", False):
-            return field_meta.default
-
         if cls.should_set_none_value(field_meta=field_meta):
             return None
 

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     ClassVar,
     Generic,
-    Literal,
     Mapping,
     TypeVar,
     cast,
@@ -21,7 +20,7 @@ from polyfactory.utils.helpers import unwrap_new_type, unwrap_optional
 from polyfactory.utils.predicates import is_optional_union, is_safe_subclass
 
 try:
-    from pydantic import BaseModel
+    from pydantic import VERSION, BaseModel
     from pydantic.fields import FieldInfo
 except ImportError as e:
     raise MissingDependencyException("pydantic is not installed") from e
@@ -29,10 +28,7 @@ except ImportError as e:
 try:
     from pydantic.fields import ModelField  # type: ignore[attr-defined]
 
-    pydantic_version: Literal[1, 2] = 1
 except ImportError:
-    pydantic_version = 2
-
     ModelField = Any
     from pydantic_core import PydanticUndefined as Undefined
 
@@ -169,7 +165,7 @@ class PydanticFieldMeta(FieldMeta):
         )
 
         # pydantic v1 has constraints set for these values, but we generate them using faker
-        if pydantic_version == 1 and unwrap_optional(annotation) in (
+        if VERSION.startswith("1") and unwrap_optional(annotation) in (
             AnyUrl,
             HttpUrl,
             KafkaDsn,
@@ -256,7 +252,7 @@ class ModelFactory(Generic[T], BaseFactory[T]):
 
         """
         if "_fields_metadata" not in cls.__dict__:
-            if pydantic_version == 1:
+            if VERSION.startswith("1"):
                 cls._fields_metadata = [
                     PydanticFieldMeta.from_model_field(
                         field,

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -7,9 +7,12 @@ from typing import (
     ClassVar,
     Generic,
     Mapping,
+    Tuple,
     TypeVar,
     cast,
 )
+
+from typing_extensions import Literal, get_args, get_origin
 
 from polyfactory.collection_extender import CollectionExtender
 from polyfactory.constants import MAX_COLLECTION_LENGTH, MIN_COLLECTION_LENGTH, RANDOMIZE_COLLECTION_LENGTH
@@ -36,7 +39,6 @@ if TYPE_CHECKING:
     from random import Random
 
     from typing_extensions import TypeGuard
-
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -123,7 +125,9 @@ class PydanticFieldMeta(FieldMeta):
         from pydantic import AmqpDsn, AnyHttpUrl, AnyUrl, HttpUrl, KafkaDsn, PostgresDsn, RedisDsn
         from pydantic.fields import DeferredType, Undefined  # type: ignore
 
-        if callable(model_field.default_factory):
+        if model_field.default is not Undefined:
+            default_value = model_field.default
+        elif callable(model_field.default_factory):
             default_value = model_field.default_factory()
         else:
             default_value = model_field.default if model_field.default is not Undefined else Null
@@ -140,7 +144,6 @@ class PydanticFieldMeta(FieldMeta):
         constraints = cast(
             "Constraints",
             {
-                "constant": bool(model_field.field_info.const) or None,
                 "ge": getattr(outer_type, "ge", model_field.field_info.ge),
                 "gt": getattr(outer_type, "gt", model_field.field_info.gt),
                 "le": getattr(outer_type, "le", model_field.field_info.le),
@@ -165,7 +168,7 @@ class PydanticFieldMeta(FieldMeta):
         )
 
         # pydantic v1 has constraints set for these values, but we generate them using faker
-        if VERSION.startswith("1") and unwrap_optional(annotation) in (
+        if unwrap_optional(annotation) in (
             AnyUrl,
             HttpUrl,
             KafkaDsn,
@@ -175,6 +178,11 @@ class PydanticFieldMeta(FieldMeta):
             AnyHttpUrl,
         ):
             constraints = {}
+
+        if model_field.field_info.const and (
+            default_value is None or isinstance(default_value, (int, bool, str, bytes))
+        ):
+            annotation = Literal[default_value]  # pyright: ignore
 
         children: list[FieldMeta] = []
         if model_field.key_field or model_field.sub_fields:
@@ -195,7 +203,7 @@ class PydanticFieldMeta(FieldMeta):
                 for sub_field in fields_to_iterate
             )
             type_arg_to_sub_field = dict(zip(type_args, fields_to_iterate))
-            if outer_type.__origin__ == tuple and outer_type.__args__[-1] == Ellipsis:
+            if get_origin(outer_type) in (tuple, Tuple) and get_args(outer_type)[-1] == Ellipsis:
                 # pydantic removes ellipses from Tuples in sub_fields
                 type_args += (...,)
             extended_type_args = CollectionExtender.extend_type_args(annotation, type_args, number_of_args)

--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -39,7 +39,6 @@ class Constraints(TypedDict):
     """Metadata regarding a type constraints, if any"""
 
     allow_inf_nan: NotRequired[bool]
-    constant: NotRequired[bool]
     decimal_places: NotRequired[int]
     ge: NotRequired[int | float | Decimal]
     gt: NotRequired[int | float | Decimal]
@@ -183,7 +182,6 @@ class FieldMeta:
                         k: v
                         for k, v in {
                             "allow_inf_nan": getattr(value, "allow_inf_nan", None),
-                            "constant": getattr(value, "const", None) is not None,
                             "decimal_places": getattr(value, "decimal_places", None),
                             "ge": getattr(value, "ge", None),
                             "gt": getattr(value, "gt", None),

--- a/tests/constraints/test_list_constraints.py
+++ b/tests/constraints/test_list_constraints.py
@@ -5,9 +5,10 @@ from typing import Any, List
 import pytest
 from hypothesis import given
 from hypothesis.strategies import integers
+from pydantic import VERSION
 
 from polyfactory.exceptions import ParameterException
-from polyfactory.factories.pydantic_factory import ModelFactory, pydantic_version
+from polyfactory.factories.pydantic_factory import ModelFactory
 from polyfactory.field_meta import FieldMeta
 from polyfactory.value_generators.constrained_collections import (
     handle_constrained_collection,
@@ -74,7 +75,9 @@ def test_handle_constrained_list_with_min_items(
     assert len(result) >= min_items
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9) and pydantic_version == 2, reason="fails on python 3.8 with pydantic v2")
+@pytest.mark.skipif(
+    sys.version_info < (3, 9) and VERSION.startswith("2"), reason="fails on python 3.8 with pydantic v2"
+)
 @pytest.mark.parametrize("t_type", tuple(ModelFactory.get_provider_map()))
 def test_handle_constrained_list_with_different_types(t_type: Any) -> None:
     field_meta = FieldMeta.from_type(List[t_type], name="test", random=Random())

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,9 +1,9 @@
 from uuid import uuid4
 
 import pytest
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import VERSION, BaseModel, Field, ValidationError
 
-from polyfactory.factories.pydantic_factory import ModelFactory, pydantic_version
+from polyfactory.factories.pydantic_factory import ModelFactory
 from tests.models import PersonFactoryWithDefaults, Pet, PetFactory
 
 
@@ -74,7 +74,7 @@ def test_factory_use_construct() -> None:
         PetFactory.build(age=invalid_age)
 
 
-@pytest.mark.skipif(pydantic_version == 2, reason="pydantic 1 only test")
+@pytest.mark.skipif(VERSION.startswith("2"), reason="pydantic 1 only test")
 def test_build_instance_by_field_alias_with_allow_population_by_field_name_flag_pydantic_v1() -> None:
     class MyModel(BaseModel):
         aliased_field: str = Field(..., alias="special_field")
@@ -89,7 +89,7 @@ def test_build_instance_by_field_alias_with_allow_population_by_field_name_flag_
     assert instance.aliased_field == "some"
 
 
-@pytest.mark.skipif(pydantic_version == 1, reason="pydantic 2 only test")
+@pytest.mark.skipif(VERSION.startswith("1"), reason="pydantic 2 only test")
 def test_build_instance_by_field_alias_with_populate_by_name_flag_pydantic_v2() -> None:
     class MyModel(BaseModel):
         model_config = {"populate_by_name": True}

--- a/tests/test_complex_types.py
+++ b/tests/test_complex_types.py
@@ -20,11 +20,11 @@ from typing import (
 )
 
 import pytest
-from pydantic import BaseModel
+from pydantic import VERSION, BaseModel
 
 from polyfactory.exceptions import ParameterException
 from polyfactory.factories import DataclassFactory
-from polyfactory.factories.pydantic_factory import ModelFactory, pydantic_version
+from polyfactory.factories.pydantic_factory import ModelFactory
 from tests.models import Person
 
 
@@ -80,7 +80,7 @@ def test_handles_complex_typing_with_embedded_models() -> None:
     assert result.person_list[0].pets
 
 
-@pytest.mark.skipif(pydantic_version == 2, reason="pydantic 1 only test")
+@pytest.mark.skipif(VERSION.startswith("2"), reason="pydantic 1 only test")
 def test_handles_complex_typing_with_custom_root_type() -> None:
     class MyModel(BaseModel):
         __root__: List[int]

--- a/tests/test_constrained_attribute_parsing.py
+++ b/tests/test_constrained_attribute_parsing.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Tuple
 
 import pytest
 from pydantic import (
+    VERSION,
     BaseModel,
     Field,
     conbytes,
@@ -17,13 +18,13 @@ from pydantic import (
     constr,
 )
 
-from polyfactory.factories.pydantic_factory import ModelFactory, pydantic_version
+from polyfactory.factories.pydantic_factory import ModelFactory
 from tests.models import Person
 
 pattern = r"(a|b|c)zz"
 
 
-@pytest.mark.skipif(pydantic_version == 2, reason="pydantic 1 only test")
+@pytest.mark.skipif(VERSION.startswith("2"), reason="pydantic 1 only test")
 def test_constrained_attribute_parsing_pydantic_v1() -> None:
     class ConstrainedModel(BaseModel):
         conbytes_field: conbytes()  # type: ignore[valid-type]
@@ -85,7 +86,7 @@ def test_constrained_attribute_parsing_pydantic_v1() -> None:
     assert result.optional_field is None or len(result.optional_field) >= 1
 
 
-@pytest.mark.skipif(pydantic_version == 2, reason="pydantic 1 only test")
+@pytest.mark.skipif(VERSION.startswith("2"), reason="pydantic 1 only test")
 def test_complex_constrained_attribute_parsing_pydantic_v1() -> None:
     class MyModel(BaseModel):
         conlist_with_model_field: conlist(Person, min_items=3)  # type: ignore[valid-type]
@@ -107,7 +108,7 @@ def test_complex_constrained_attribute_parsing_pydantic_v1() -> None:
     assert all(isinstance(v, Person) for v in list(result.conlist_with_complex_type[0].values())[0])
 
 
-@pytest.mark.skipif(pydantic_version == 2, reason="pydantic 1 only test")
+@pytest.mark.skipif(VERSION.startswith("2"), reason="pydantic 1 only test")
 def test_nested_constrained_attribute_handling_pydantic_1() -> None:
     # subclassing the constrained fields is not documented by pydantic, but is supported apparently
 
@@ -180,7 +181,8 @@ def test_nested_constrained_attribute_handling_pydantic_1() -> None:
 
 
 @pytest.mark.skipif(
-    pydantic_version == 1 or sys.version_info < (3, 9), reason="pydantic 2 only test, does not work correctly in py 3.8"
+    VERSION.startswith("1") or sys.version_info < (3, 9),
+    reason="pydantic 2 only test, does not work correctly in py 3.8",
 )
 def test_nested_constrained_attribute_handling_pydantic_2() -> None:
     # subclassing the constrained fields is not documented by pydantic, but is supported apparently
@@ -209,7 +211,8 @@ def test_nested_constrained_attribute_handling_pydantic_2() -> None:
 
 
 @pytest.mark.skipif(
-    pydantic_version == 1 or sys.version_info < (3, 9), reason="pydantic 2 only test, does not work correctly in py 3.8"
+    VERSION.startswith("1") or sys.version_info < (3, 9),
+    reason="pydantic 2 only test, does not work correctly in py 3.8",
 )
 def test_constrained_attribute_parsing_pydantic_v2() -> None:
     class ConstrainedModel(BaseModel):
@@ -270,7 +273,7 @@ def test_constrained_attribute_parsing_pydantic_v2() -> None:
     assert result.optional_field is None or len(result.optional_field) >= 1
 
 
-@pytest.mark.skipif(pydantic_version == 1, reason="pydantic 2 only test")
+@pytest.mark.skipif(VERSION.startswith("1"), reason="pydantic 2 only test")
 def test_complex_constrained_attribute_parsing_pydantic_v2() -> None:
     class MyModel(BaseModel):
         conlist_with_model_field: conlist(Person, min_length=3)  # type: ignore[valid-type]

--- a/tests/test_data_parsing.py
+++ b/tests/test_data_parsing.py
@@ -154,18 +154,14 @@ def test_embedded_factories_parsing() -> None:
 
 
 def test_type_property_parsing() -> None:
-    if pydantic.VERSION.startswith("2"):
-        # pydantic v2 only types
-
-        class Base(BaseModel):
+    class Base(BaseModel):
+        if pydantic.VERSION.startswith("2"):
             MongoDsn_pydantic_type: pydantic.networks.MongoDsn
             MariaDBDsn_pydantic_type: pydantic.networks.MariaDBDsn
             CockroachDsn_pydantic_type: pydantic.networks.CockroachDsn
             MySQLDsn_pydantic_type: pydantic.networks.MySQLDsn
 
-    else:
-
-        class Base(BaseModel):  # type: ignore[no-redef]
+        else:
             PyObject_pydantic_type: pydantic.types.PyObject
             Color_pydantic_type: pydantic.color.Color
 

--- a/tests/test_data_parsing.py
+++ b/tests/test_data_parsing.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Callable, Literal, Optional
 from uuid import UUID
 
+import pydantic
 import pytest
 from pydantic import (
     UUID1,
@@ -55,7 +56,6 @@ from pydantic import (
     StrictInt,
     StrictStr,
 )
-from pydantic.color import Color
 from typing_extensions import TypeAlias
 
 from polyfactory.exceptions import ParameterException
@@ -154,21 +154,20 @@ def test_embedded_factories_parsing() -> None:
 
 
 def test_type_property_parsing() -> None:
-    try:
+    if pydantic.VERSION.startswith("2"):
         # pydantic v2 only types
-        from pydantic.networks import CockroachDsn, MariaDBDsn, MongoDsn, MySQLDsn
 
         class Base(BaseModel):
-            MongoDsn_pydantic_type: MongoDsn
-            MariaDBDsn_pydantic_type: MariaDBDsn
-            CockroachDsn_pydantic_type: CockroachDsn
-            MySQLDsn_pydantic_type: MySQLDsn
+            MongoDsn_pydantic_type: pydantic.networks.MongoDsn
+            MariaDBDsn_pydantic_type: pydantic.networks.MariaDBDsn
+            CockroachDsn_pydantic_type: pydantic.networks.CockroachDsn
+            MySQLDsn_pydantic_type: pydantic.networks.MySQLDsn
 
-    except ImportError:
-        from pydantic.types import PyObject
+    else:
 
         class Base(BaseModel):  # type: ignore[no-redef]
-            PyObject_pydantic_type: PyObject
+            PyObject_pydantic_type: pydantic.types.PyObject
+            Color_pydantic_type: pydantic.color.Color
 
     class MyModel(Base):
         object_field: object
@@ -219,7 +218,6 @@ def test_type_property_parsing() -> None:
         DirectoryPath_pydantic_type: DirectoryPath
         EmailStr_pydantic_type: EmailStr
         NameEmail_pydantic_type: NameEmail
-        Color_pydantic_type: Color
         Json_pydantic_type: Json
         AnyUrl_pydantic_type: AnyUrl
         AnyHttpUrl_pydantic_type: AnyHttpUrl

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -1,9 +1,9 @@
 from typing import Dict, Union
 
 import pytest
-from pydantic import BaseModel
+from pydantic import VERSION, BaseModel
 
-from polyfactory.factories.pydantic_factory import ModelFactory, pydantic_version
+from polyfactory.factories.pydantic_factory import ModelFactory
 
 
 def test_passing_nested_dict() -> None:
@@ -26,7 +26,7 @@ def test_passing_nested_dict() -> None:
 
 
 @pytest.mark.skipif(
-    pydantic_version == 2,
+    VERSION.startswith("2"),
     reason="indeterminate behaviour in pydantic 2.0",
 )
 def test_dict_with_union_random_types() -> None:

--- a/tests/test_new_types.py
+++ b/tests/test_new_types.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, NewType, Optional, Tuple, Union
 
 import pytest
 from pydantic import (
+    VERSION,
     BaseModel,
     PositiveFloat,
     conbytes,
@@ -17,7 +18,7 @@ from pydantic import (
     constr,
 )
 
-from polyfactory.factories.pydantic_factory import ModelFactory, pydantic_version
+from polyfactory.factories.pydantic_factory import ModelFactory
 
 
 def test_new_types() -> None:
@@ -68,7 +69,7 @@ def test_complex_new_types() -> None:
     assert isinstance(result.nested_model_field.nested_int_field, int)
 
 
-@pytest.mark.skipif(pydantic_version == 2, reason="https://github.com/pydantic/pydantic/issues/5907")
+@pytest.mark.skipif(VERSION.startswith("2"), reason="https://github.com/pydantic/pydantic/issues/5907")
 def test_constrained_new_types() -> None:
     ConBytes = NewType("ConBytes", conbytes(min_length=2, max_length=4))  # type: ignore[misc]
     ConStr = NewType("ConStr", constr(min_length=10, max_length=15))  # type: ignore[misc]
@@ -78,7 +79,7 @@ def test_constrained_new_types() -> None:
     ConDate = NewType("ConDate", condate(gt=date.today()))  # type: ignore[misc]
     ConMyPositiveFloat = NewType("ConMyPositiveFloat", PositiveFloat)
 
-    if pydantic_version == 1:
+    if VERSION.startswith("1"):
         ConList = NewType("ConList", conlist(item_type=int, min_items=3))  # type: ignore
         ConSet = NewType("ConSet", conset(item_type=int, min_items=4))  # type: ignore
         ConFrozenSet = NewType("ConFrozenSet", confrozenset(item_type=str, min_items=5))  # type: ignore

--- a/tests/test_odmantic_factory.py
+++ b/tests/test_odmantic_factory.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime
 from typing import Any, Dict, FrozenSet, List, Set, Tuple
 from uuid import UUID
@@ -122,6 +123,7 @@ def test_variable_length(type_: Any) -> None:
     assert len(result.items) == 3
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="flaky in python 3.8")
 def test_variable_length__dict() -> None:
     class MyModel(Model):  # type: ignore
         items: Dict[bson.Int64, UUID]

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -1,0 +1,16 @@
+import pytest
+from pydantic import VERSION, BaseModel, Field
+
+from polyfactory.factories.pydantic_factory import ModelFactory
+
+
+@pytest.mark.skipif(VERSION.startswith("2"), reason="pydantic v1 only functionality")
+def test_const() -> None:
+    class A(BaseModel):
+        v: int = Field(1, const=True)
+
+    class AFactory(ModelFactory[A]):
+        __model__ = A
+
+    for _ in range(5):
+        assert AFactory.build()

--- a/tests/test_random_seed.py
+++ b/tests/test_random_seed.py
@@ -1,16 +1,18 @@
 from random import randint
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import VERSION, BaseModel, Field
 
-from polyfactory.factories.pydantic_factory import ModelFactory, pydantic_version
+from polyfactory.factories.pydantic_factory import ModelFactory
 
 
 def test_random_seed() -> None:
     class MyModel(BaseModel):
         id: int
         special_id: str = (
-            Field(pattern=r"ID-[1-9]{3}\.[1-9]{3}") if pydantic_version == 2 else Field(regex=r"ID-[1-9]{3}\.[1-9]{3}")
+            Field(pattern=r"ID-[1-9]{3}\.[1-9]{3}")
+            if VERSION.startswith("2")
+            else Field(regex=r"ID-[1-9]{3}\.[1-9]{3}")
         )
 
     class MyModelFactory(ModelFactory):


### PR DESCRIPTION
This PR fixes an issue with `const` not working for pydantic v1 factories. It also does some cleanup of pydantic related tests.