### PR TITLE
fix: include pydantic Field constraints when using Optional type

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,7 +24,7 @@ Workflow
 4. Make whatever changes and additions you wish and commit these - please try to keep your commit history clean.
    1. .. note:: 100% tests are mandatory.
 5. Once you are ready, add a PR in the main repo.
-6. Create a pull request to the main repository with an explanation of your changes.
+6. Create a pull request to the main repository with an explanation of your changes. The title should follow the `conventional commits <https://www.conventionalcommits.org/en/v1.0.0/>`_ convention.
 
 
 Project documentation

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,11 +26,6 @@ Workflow
 5. Once you are ready, add a PR in the main repo.
 6. Create a pull request to the main repository with an explanation of your changes.
 
-.. note::
-    The test suite requires having an instance of MongoDB available. You can launch one
-    using the root level docker-compose config with ``docker-compose up --detach``, or
-    by any other means.
-
 
 Project documentation
 ---------------------

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 .PHONY: docs
 
+install:
+	poetry install --extras full --with docs --no-ansi --sync
+	pre-commit install
+.PHONY: install
+
 docs-clean:
 	rm -rf docs/_build
 

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -57,7 +57,7 @@ from polyfactory.utils.predicates import (
     get_type_origin,
     is_any,
     is_literal,
-    is_optional_union,
+    is_optional,
     is_safe_subclass,
     is_union,
 )
@@ -678,7 +678,7 @@ class BaseFactory(ABC, Generic[T]):
         """
         return (
             cls.__allow_none_optionals__
-            and is_optional_union(field_meta.annotation)
+            and is_optional(field_meta.annotation)
             and create_random_boolean(random=cls.__random__)
         )
 

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -26,7 +26,7 @@ from polyfactory.exceptions import MissingDependencyException
 from polyfactory.factories.base import BaseFactory
 from polyfactory.field_meta import Constraints, FieldMeta, Null
 from polyfactory.utils.helpers import unwrap_new_type, unwrap_optional
-from polyfactory.utils.predicates import is_optional_union, is_safe_subclass, is_union
+from polyfactory.utils.predicates import is_optional, is_safe_subclass, is_union
 
 try:
     from pydantic import VERSION, BaseModel, Json
@@ -107,7 +107,7 @@ class PydanticFieldMeta(FieldMeta):
         name = field_info.alias if field_info.alias and use_alias else field_name
 
         # pydantic v2 does not always propagate metadata for Union types
-        if not field_info.metadata and is_optional_union(annotation):
+        if not field_info.metadata and is_optional(annotation):
             field_info = FieldInfo.from_annotation(unwrap_optional(annotation))
         elif is_union(annotation):
             children = [

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -106,8 +106,8 @@ class PydanticFieldMeta(FieldMeta):
         constraints: Constraints = {}
         name = field_info.alias if field_info.alias and use_alias else field_name
 
-        # pydantic v2 do not propagate metadata for Union types
-        if is_optional_union(annotation):
+        # pydantic v2 does not always propagate metadata for Union types
+        if not field_info.metadata and is_optional_union(annotation):
             field_info = FieldInfo.from_annotation(unwrap_optional(annotation))
         elif is_union(annotation):
             children = [

--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -9,7 +9,7 @@ from polyfactory.constants import TYPE_MAPPING
 from polyfactory.utils.predicates import (
     is_annotated,
     is_new_type,
-    is_optional_union,
+    is_optional,
     is_union,
 )
 
@@ -50,7 +50,7 @@ def unwrap_optional(annotation: Any) -> Any:
 
     :returns: A type annotation
     """
-    while is_optional_union(annotation):
+    while is_optional(annotation):
         annotation = next(arg for arg in get_args(annotation) if arg not in (type(None), None))
     return annotation
 
@@ -64,10 +64,10 @@ def unwrap_annotation(annotation: Any, random: Random) -> Any:
     :returns: The unwrapped annotation.
 
     """
-    while is_optional_union(annotation) or is_union(annotation) or is_new_type(annotation) or is_annotated(annotation):
+    while is_optional(annotation) or is_union(annotation) or is_new_type(annotation) or is_annotated(annotation):
         if is_new_type(annotation):
             annotation = unwrap_new_type(annotation)
-        elif is_optional_union(annotation):
+        elif is_optional(annotation):
             annotation = unwrap_optional(annotation)
         elif is_annotated(annotation):
             annotation = unwrap_annotated(annotation, random=random)[0]

--- a/polyfactory/utils/predicates.py
+++ b/polyfactory/utils/predicates.py
@@ -79,7 +79,7 @@ def is_union(annotation: Any) -> "TypeGuard[Any | Any]":
 
 
 def is_optional_union(annotation: Any) -> "TypeGuard[Any | None]":
-    """Determine whether a given annotation is 'typing.Optional'.
+    """Determine whether a given annotation is 'typing.Union[XXXX, NoneType]'.
 
     :param annotation: A type annotation.
 

--- a/polyfactory/utils/predicates.py
+++ b/polyfactory/utils/predicates.py
@@ -78,8 +78,8 @@ def is_union(annotation: Any) -> "TypeGuard[Any | Any]":
     return get_type_origin(annotation) in UNION_TYPES
 
 
-def is_optional_union(annotation: Any) -> "TypeGuard[Any | None]":
-    """Determine whether a given annotation is 'typing.Union[XXXX, NoneType]'.
+def is_optional(annotation: Any) -> "TypeGuard[Any | None]":
+    """Determine whether a given annotation is 'typing.Optional'.
 
     :param annotation: A type annotation.
 

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from typing import Optional
 
 import pytest
 from pydantic import VERSION, BaseModel, Field, Json, ValidationError
@@ -24,13 +25,13 @@ def test_optional_with_constraints() -> None:
     """this is a flaky test - because it depends on randomness, hence it's been re-ran multiple times."""
 
     class A(BaseModel):
-        a: int | None = Field(None, ge=0, le=1)
+        a: Optional[int] = Field(None, ge=0, le=1)
 
     class AFactory(ModelFactory[A]):
         __model__ = A
 
     has_failed = False
-    exception: Exception | None = None
+    exception: Optional[Exception] = None
     for _ in range(100):
         try:
             assert isinstance(AFactory.build().a, (int, type(None)))

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import sys
 from typing import Optional
 

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -2,7 +2,7 @@ import sys
 from typing import Optional
 
 import pytest
-from pydantic import VERSION, BaseModel, Field, Json, ValidationError
+from pydantic import VERSION, BaseModel, Field, Json
 
 from polyfactory.factories.pydantic_factory import ModelFactory
 
@@ -20,25 +20,18 @@ def test_const() -> None:
 
 
 def test_optional_with_constraints() -> None:
-    """this is a flaky test - because it depends on randomness, hence it's been re-ran multiple times."""
+    # Setting random seed so that we get a non-optional value
+    random_seed = 1
 
     class A(BaseModel):
-        a: Optional[int] = Field(None, ge=0, le=1)
+        a: Optional[float] = Field(None, ge=0, le=1)
 
     class AFactory(ModelFactory[A]):
         __model__ = A
+        __random_seed__ = random_seed
 
-    has_failed = False
-    exception: Optional[Exception] = None
-    for _ in range(100):
-        try:
-            assert isinstance(AFactory.build().a, (int, type(None)))
-        except ValidationError as e:
-            exception = e
-            has_failed = True
-
-    if has_failed:
-        pytest.fail(reason=str(exception))
+    # verify no pydantic.ValidationError is thrown
+    assert isinstance(AFactory.build().a, float)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.9 or higher")


### PR DESCRIPTION
Hello! :wave: 

I had initially commented [here](https://github.com/litestar-org/polyfactory/issues/230#issuecomment-1659714195), but this was a separate issue. So I just went ahead and fixed it.

[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- Fix pydantic metadata parsing on optional field
