### PR TITLE
feat: add pydantic's AwareDatetime to the mock map

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -124,10 +124,6 @@ def _create_pydantic_type_map(cls: type[BaseFactory[Any]]) -> dict[type, Callabl
             pydantic.FutureDate: cls.__faker__.future_date,
         }
 
-        if pydantic.VERSION.startswith("2"):
-            # v2 exclusive values
-            mapping.update({pydantic.AwareDatetime: partial(cls.__faker__.date_time, timezone.utc)})
-
         if pydantic.VERSION.startswith("1"):
             # v1 only values - these will raise an exception in v2
             # in pydantic v2 these are all aliases for Annotated with a constraint.
@@ -146,6 +142,15 @@ def _create_pydantic_type_map(cls: type[BaseFactory[Any]]) -> dict[type, Callabl
                     pydantic.UUID4: cls.__faker__.uuid4,
                     pydantic.UUID5: lambda: uuid5(NAMESPACE_DNS, cls.__faker__.pystr()),
                     pydantic.color.Color: cls.__faker__.hex_color,  # pyright: ignore
+                }
+            )
+        else:
+            mapping.update(
+                {
+                    pydantic.PastDatetime: cls.__faker__.past_datetime,
+                    pydantic.FutureDatetime: cls.__faker__.future_datetime,
+                    pydantic.AwareDatetime: partial(cls.__faker__.date_time, timezone.utc),
+                    pydantic.NaiveDatetime: cls.__faker__.date_time,
                 }
             )
 

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections import Counter, abc, deque
 from contextlib import suppress
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from enum import EnumMeta
 from functools import partial
@@ -123,6 +123,10 @@ def _create_pydantic_type_map(cls: type[BaseFactory[Any]]) -> dict[type, Callabl
             pydantic.PastDate: cls.__faker__.past_date,
             pydantic.FutureDate: cls.__faker__.future_date,
         }
+
+        if pydantic.VERSION.startswith("2"):
+            # v2 exclusive values
+            mapping.update({pydantic.AwareDatetime: partial(cls.__faker__.date_time, timezone.utc)})
 
         if pydantic.VERSION.startswith("1"):
             # v1 only values - these will raise an exception in v2

--- a/tests/test_data_parsing.py
+++ b/tests/test_data_parsing.py
@@ -160,7 +160,10 @@ def test_type_property_parsing() -> None:
             MariaDBDsn_pydantic_type: pydantic.networks.MariaDBDsn
             CockroachDsn_pydantic_type: pydantic.networks.CockroachDsn
             MySQLDsn_pydantic_type: pydantic.networks.MySQLDsn
+            PastDatetime_pydantic_type: pydantic.PastDatetime
+            FutureDatetime_pydantic_type: pydantic.FutureDatetime
             AwareDatetime_pydantic_type: pydantic.AwareDatetime
+            NaiveDatetime_pydantic_type: pydantic.NaiveDatetime
 
         else:
             PyObject_pydantic_type: pydantic.types.PyObject

--- a/tests/test_data_parsing.py
+++ b/tests/test_data_parsing.py
@@ -160,6 +160,7 @@ def test_type_property_parsing() -> None:
             MariaDBDsn_pydantic_type: pydantic.networks.MariaDBDsn
             CockroachDsn_pydantic_type: pydantic.networks.CockroachDsn
             MySQLDsn_pydantic_type: pydantic.networks.MySQLDsn
+            AwareDatetime_pydantic_type: pydantic.AwareDatetime
 
         else:
             PyObject_pydantic_type: pydantic.types.PyObject


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [X] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [X] Pre-Commit Checks were ran and passed
- [X] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- Adds the new (post v2) [Pydantic's AwareDatetime](https://docs.pydantic.dev/2.2/usage/types/datetime/#pydantic-date-types) type to the types map

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- 
