### PR TITLE
fix: use full Python version for venv cache

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,7 +1,5 @@
 {
-  "files": [
-    "README.md"
-  ],
+  "files": ["README.md"],
   "imageSize": 100,
   "commit": false,
   "commitConvention": "angular",
@@ -11,320 +9,238 @@
       "name": "Na'aman Hirschfeld",
       "avatar_url": "https://avatars.githubusercontent.com/u/30733348?v=4",
       "profile": "https://github.com/Goldziher",
-      "contributions": [
-        "maintenance",
-        "infra",
-        "test",
-        "code",
-        "doc"
-      ]
+      "contributions": ["maintenance", "infra", "test", "code", "doc"]
     },
     {
       "login": "JacobCoffee",
       "name": "Jacob Coffee",
       "avatar_url": "https://avatars.githubusercontent.com/u/45884264?v=4",
       "profile": "https://scriptr.dev/",
-      "contributions": [
-        "maintenance",
-        "doc",
-        "test"
-      ]
+      "contributions": ["maintenance", "doc", "test"]
     },
     {
       "login": "provinzkraut",
       "name": "Janek Nouvertné",
       "avatar_url": "https://avatars.githubusercontent.com/u/25355197?v=4",
       "profile": "https://github.com/provinzkraut",
-      "contributions": [
-        "maintenance",
-        "doc",
-        "test",
-        "code"
-      ]
+      "contributions": ["maintenance", "doc", "test", "code"]
     },
     {
       "login": "peterschutt",
       "name": "Peter Schutt",
       "avatar_url": "https://avatars.githubusercontent.com/u/20659309?v=4",
       "profile": "https://schutt.io",
-      "contributions": [
-        "maintenance",
-        "test",
-        "code",
-        "doc"
-      ]
+      "contributions": ["maintenance", "test", "code", "doc"]
     },
     {
       "login": "mdczaplicki",
       "name": "Marek Czaplicki",
       "avatar_url": "https://avatars.githubusercontent.com/u/9108586?v=4",
       "profile": "https://czaplicki.it/",
-      "contributions": [
-        "code",
-        "test"
-      ]
+      "contributions": ["code", "test"]
     },
     {
       "login": "przybylop",
       "name": "Piotr Przybyło",
       "avatar_url": "https://avatars.githubusercontent.com/u/82805821?v=4",
       "profile": "https://github.com/przybylop",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "sygutss",
       "name": "sygutss",
       "avatar_url": "https://avatars.githubusercontent.com/u/48909366?v=4",
       "profile": "https://github.com/sygutss",
-      "contributions": [
-        "bug",
-        "code"
-      ]
+      "contributions": ["bug", "code"]
     },
     {
       "login": "chrisbeardy",
       "name": "chrisbeardy",
       "avatar_url": "https://avatars.githubusercontent.com/u/20585410?v=4",
       "profile": "https://github.com/chrisbeardy",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "guacs",
       "name": "guacs",
       "avatar_url": "https://avatars.githubusercontent.com/u/126393040?v=4",
       "profile": "https://github.com/guacs",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "VSHUMILIN97",
       "name": "Vadim",
       "avatar_url": "https://avatars.githubusercontent.com/u/27234763?v=4",
       "profile": "https://github.com/VSHUMILIN97",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Simske",
       "name": "Simske",
       "avatar_url": "https://avatars.githubusercontent.com/u/2445660?v=4",
       "profile": "https://github.com/Simske",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "sondrelg",
       "name": "Sondre Lillebø Gundersen",
       "avatar_url": "https://avatars.githubusercontent.com/u/25310870?v=4",
       "profile": "https://github.com/sondrelg",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "mciszczon",
       "name": "Mateusz Ciszczoń",
       "avatar_url": "https://avatars.githubusercontent.com/u/1078369?v=4",
       "profile": "https://mciszczon.pl/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "phbernardes",
       "name": "Pedro Bernardes",
       "avatar_url": "https://avatars.githubusercontent.com/u/18899993?v=4",
       "profile": "https://www.linkedin.com/in/pedro-bernardes/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "lindycoder",
       "name": "Martin Roy",
       "avatar_url": "https://avatars.githubusercontent.com/u/12926519?v=4",
       "profile": "https://github.com/lindycoder",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Butch78",
       "name": "Matthew Aylward ",
       "avatar_url": "https://avatars.githubusercontent.com/u/19205392?v=4",
       "profile": "http://matthewtyleraylward.com",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "EltonChou",
       "name": "Elton H.Y. Chou",
       "avatar_url": "https://avatars.githubusercontent.com/u/12560310?v=4",
       "profile": "https://github.com/EltonChou",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "nguyent",
       "name": "Thang",
       "avatar_url": "https://avatars.githubusercontent.com/u/576848?v=4",
       "profile": "https://github.com/nguyent",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "DaanRademaker",
       "name": "Daan",
       "avatar_url": "https://avatars.githubusercontent.com/u/29598493?v=4",
       "profile": "https://github.com/DaanRademaker",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "lyz-code",
       "name": "Lyz",
       "avatar_url": "https://avatars.githubusercontent.com/u/24810987?v=4",
       "profile": "https://lyz-code.github.io/blue-book/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "thorin-schiffer",
       "name": "Thorin Schiffer",
       "avatar_url": "https://avatars.githubusercontent.com/u/3502492?v=4",
       "profile": "https://portfolio.schiffer.pro/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "Iipin",
       "name": "Iipin",
       "avatar_url": "https://avatars.githubusercontent.com/u/52832022?v=4",
       "profile": "https://github.com/Iipin",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "avihai-yosef",
       "name": "avihai-yosef",
       "avatar_url": "https://avatars.githubusercontent.com/u/79567307?v=4",
       "profile": "https://github.com/avihai-yosef",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "anthonyh209",
       "name": "anthonyh209",
       "avatar_url": "https://avatars.githubusercontent.com/u/33107540?v=4",
       "profile": "https://github.com/anthonyh209",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "ReznikovRoman",
       "name": "Roman Reznikov",
       "avatar_url": "https://avatars.githubusercontent.com/u/44291988?v=4",
       "profile": "http://linkedin.com/in/roman-reznikov",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "gigelu",
       "name": "gigelu",
       "avatar_url": "https://avatars.githubusercontent.com/u/270697?v=4",
       "profile": "https://github.com/gigelu",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "roeeyn",
       "name": "Rodrigo Medina",
       "avatar_url": "https://avatars.githubusercontent.com/u/13385000?v=4",
       "profile": "https://github.com/roeeyn",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "gegnew",
       "name": "Gerrit Egnew",
       "avatar_url": "https://avatars.githubusercontent.com/u/35822787?v=4",
       "profile": "https://gerritegnew.info/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "danielkatzan",
       "name": "danielkatzan",
       "avatar_url": "https://avatars.githubusercontent.com/u/9249066?v=4",
       "profile": "https://github.com/danielkatzan",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "abdulhaq-e",
       "name": "Abdulhaq Emhemmed",
       "avatar_url": "https://avatars.githubusercontent.com/u/2532125?v=4",
       "profile": "https://github.com/abdulhaq-e",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "klimantje",
       "name": "klimantje",
       "avatar_url": "https://avatars.githubusercontent.com/u/20017047?v=4",
       "profile": "https://github.com/klimantje",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "tcrasset",
       "name": "Tom Crasset",
       "avatar_url": "https://avatars.githubusercontent.com/u/25140344?v=4",
       "profile": "https://github.com/tcrasset",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "185504a9",
       "name": "cătălin",
       "avatar_url": "https://avatars.githubusercontent.com/u/45485069?v=4",
       "profile": "https://git.roboces.dev/catalin",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "adhtruong",
       "name": "Andrew Truong",
       "avatar_url": "https://avatars.githubusercontent.com/u/40660973?v=4",
       "profile": "https://github.com/adhtruong",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     }
   ],
   "contributorsPerLine": 7,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
       - name: Set up python ${{ matrix.python-version }}
+        id: checkout-python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -47,7 +48,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: v1-venv-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.pydantic-version}}-${{ hashFiles('**/poetry.lock') }}
+          key: v1-venv-${{ runner.os }}-${{ steps.checkout-python.outputs.version }}-${{ matrix.pydantic-version}}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --extras full


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- This PR ensures that the full Python version, including the minor version, is used for the venv caching.