### PR TITLE
fix: add minimum version constraint to attrs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1844,4 +1844,4 @@ pydantic = ["pydantic"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "25094a0e7feb671a9aba503e09c2304b739b43ace6da443e647780f80aabd630"
+content-hash = "645ddd3b27998ccda4e447580caee795472ee1ec21854dc5249cc3e3c122775c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ msgspec = { version = "*", optional = true }
 odmantic = { version = "*", optional = true }
 pydantic = { version = "*", optional = true, extras = ["email"] }
 typing-extensions = "*"
-attrs = { version = "*", optional = true }
+attrs = {version = ">=22.2.0", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 hypothesis = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polyfactory"
-version = "2.8.1"
+version = "2.8.2"
 description = "Mock data generation factories"
 authors = [
     "Na'aman Hirschfeld <nhirschfeld@gmail.com>",


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- This PR adds a minimum constraint to the attrs version since the current `AttrsFactory` implementation only works with `attrs` version 22.2.0 onwards.

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- Fixes #356
