### PR TITLE
fix: properly type hint create_factory

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,6 +82,7 @@ nitpick_ignore = [
     (PY_CLASS, "Random"),
     (PY_CLASS, "Scope"),
     (PY_CLASS, "T"),
+    (PY_CLASS, "F"),
     (PY_CLASS, "P"),
     (PY_CLASS, "P.args"),
     (PY_CLASS, "P.kwargs"),

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -164,6 +164,7 @@ def _create_pydantic_type_map(cls: type[BaseFactory[Any]]) -> dict[type, Callabl
 
 
 T = TypeVar("T")
+F = TypeVar("F", bound="BaseFactory[Any]")
 
 
 class BaseFactory(ABC, Generic[T]):
@@ -487,11 +488,11 @@ class BaseFactory(ABC, Generic[T]):
 
     @classmethod
     def create_factory(
-        cls,
-        model: type,
+        cls: type[F],
+        model: type[T],
         bases: tuple[type[BaseFactory[Any]], ...] | None = None,
         **kwargs: Any,
-    ) -> type[BaseFactory[Any]]:
+    ) -> type[F]:
         """Generate a factory for the given type dynamically.
 
         :param model: A type to model.
@@ -502,7 +503,7 @@ class BaseFactory(ABC, Generic[T]):
 
         """
         return cast(
-            "Type[BaseFactory[Any]]",
+            "Type[F]",
             type(
                 f"{model.__name__}Factory",
                 (*(bases or ()), cls),


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- This PR makes the type hints for `BaseFactory.create_factory` generic to allow type checkers to properly infer the type of the created factory.

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- Fixes #358 
