### PR TITLE
docs: change the comment length in "Handling custom types" docs

### DIFF
--- a/docs/examples/handling_custom_types/test_example_1.py
+++ b/docs/examples/handling_custom_types/test_example_1.py
@@ -23,7 +23,8 @@ class Person:
     secret: CustomSecret
 
 
-# by default the factory class cannot handle unknown types, so we need to override the provider map to add it:
+# by default the factory class cannot handle unknown types,
+# so we need to override the provider map to add it:
 class PersonFactory(DataclassFactory[Person]):
     __model__ = Person
 


### PR DESCRIPTION
Previously you had to scroll to read the comment:
https://polyfactory.litestar.dev/usage/handling_custom_types.html

<img width="775" alt="Снимок экрана 2023-09-14 в 17 59 30" src="https://github.com/litestar-org/polyfactory/assets/4660275/5dd79802-9cab-47d1-947b-28f43223a32f">
<img width="789" alt="Снимок экрана 2023-09-14 в 17 59 36" src="https://github.com/litestar-org/polyfactory/assets/4660275/cf346f85-c15e-4ed7-8790-3bb034b6d307">

Now, it will be visible without scrolling.