### PR TITLE
test: make `pytest` configuration stricter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,13 +97,17 @@ include = ["polyfactory", "tests", "examples"]
 omit = ["*/tests/*"]
 
 [tool.pytest.ini_options]
-addopts = "tests docs/examples"
+addopts = "--strict-config --strict-markers tests docs/examples"
 asyncio_mode = "auto"
 filterwarnings = [
     "ignore:.*pkg_resources.declare_namespace\\('sphinxcontrib'\\).*:DeprecationWarning",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
     # Get rid those above once sphinxcontrib-mermaid doesn't use pkg_resources anymore
     # https://github.com/mgaitan/sphinxcontrib-mermaid/issues/119
+]
+markers = [
+    # Marks tests that use `attrs` library
+    "attrs",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
It also removes this warning:

```
tests/test_attrs_factory.py:13
  /Users/sobolev/Desktop/polyfactory/tests/test_attrs_factory.py:13: PytestUnknownMarkWarning: Unknown pytest.mark.attrs - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytestmark = [pytest.mark.attrs]
```