### PR TITLE
fix: Dataclass field type not used correctly

### DIFF
--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ForwardRef
 
 from typing_extensions import get_args, get_origin
 
@@ -130,3 +130,17 @@ def normalize_annotation(annotation: Any, random: Random) -> Any:
         return origin[args] if origin is not type else annotation
 
     return origin
+
+
+def evaluate_forwardref(ref: ForwardRef) -> Any:
+    """Evaluate ForwardRef to get type annotation
+
+    :param ref: A ForwardRef object
+
+    :returns: A type annotation
+
+    """
+    if sys.version_info < (3, 9):
+        return ref._evaluate(globals(), locals())
+
+    return ref._evaluate(globals(), locals(), frozenset())

--- a/tests/test_dataclass_factory.py
+++ b/tests/test_dataclass_factory.py
@@ -55,6 +55,27 @@ def test_factory_pydantic_dc() -> None:
     assert result.constrained_field >= 100
 
 
+def test_factory_sqlalchemy_dc() -> None:
+    from sqlalchemy.orm import DeclarativeBase, Mapped, MappedAsDataclass, mapped_column
+
+    class SqlAlchemyDCBase(MappedAsDataclass, DeclarativeBase):
+        pass
+
+    class SqlAlchemyDC(SqlAlchemyDCBase):
+        __tablename__ = "foo"
+
+        id: Mapped[int] = mapped_column(primary_key=True)
+        name: Mapped[str]
+
+    class SqlAlchemyDCFactory(DataclassFactory[SqlAlchemyDC]):
+        __model__ = SqlAlchemyDC
+
+    result = SqlAlchemyDCFactory.build()
+
+    assert isinstance(result.id, int)
+    assert isinstance(result.name, str)
+
+
 def test_vanilla_dc_with_embedded_model() -> None:
     @vanilla_dataclass
     class VanillaDC:
@@ -166,6 +187,36 @@ class example:
         __model__ = example
 
     assert MyFactory.process_kwargs() == {"foo": ANY}
+
+
+def test_sqlalchemy_dc_factory_with_future_annotations(create_module: Callable[[str], ModuleType]) -> None:
+    module = create_module(
+        """
+from __future__ import annotations
+
+from sqlalchemy.orm import DeclarativeBase, Mapped, MappedAsDataclass, mapped_column
+
+class SqlAlchemyDCBase(MappedAsDataclass, DeclarativeBase):  # type: ignore
+    pass
+
+class SqlAlchemyDC(SqlAlchemyDCBase):
+    __tablename__ = "foo"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+
+"""
+    )
+
+    SqlAlchemyDC: type = module.SqlAlchemyDC
+    assert SqlAlchemyDC.__annotations__ == {"id": "Mapped[int]", "name": "Mapped[str]"}
+
+    class SqlAlchemyDCFactory(DataclassFactory[SqlAlchemyDC]):  # type:ignore[valid-type]
+        __model__ = SqlAlchemyDC
+
+    result = SqlAlchemyDCFactory.build()
+    assert isinstance(result.id, int)
+    assert isinstance(result.name, str)
 
 
 def test_variable_length_tuple_generation__many_type_args() -> None:


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
- Get dataclass type information from field.type instead of using `typing.get_type_hints`

### Close Issue(s)
- Fixes https://github.com/litestar-org/polyfactory/issues/347