### PR TITLE
test: skip variable length dict test for odmantic

### DIFF
--- a/tests/test_odmantic_factory.py
+++ b/tests/test_odmantic_factory.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 from typing import Any, Dict, FrozenSet, List, Set, Tuple
 from uuid import UUID
@@ -123,7 +122,7 @@ def test_variable_length(type_: Any) -> None:
     assert len(result.items) == 3
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="flaky in python 3.8")
+@pytest.mark.skipif(True, reason="test is flaky - refer issue #362")
 def test_variable_length__dict() -> None:
     class MyModel(Model):  # type: ignore
         items: Dict[bson.Int64, UUID]


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- skip `tests/test_odmantic_factory::test_variable_length__dict` because it's very flaky (refer #362 for details)
