### PR TITLE
feat: check if fields declared on the factory belong to the model

### DIFF
--- a/docs/examples/configuration/test_example_8.py
+++ b/docs/examples/configuration/test_example_8.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
 from uuid import UUID
 
-from polyfactory import PostGenerated
+import pytest
+
+from polyfactory import ConfigurationException, PostGenerated
 from polyfactory.factories.dataclass_factory import DataclassFactory
 
 
@@ -10,15 +12,12 @@ class Person:
     id: UUID
 
 
-class PersonFactory(DataclassFactory[Person]):
-    __model__ = Person
-    __check_model__ = True
-    unknown_field = PostGenerated(lambda: "foo")
+with pytest.raises(
+    ConfigurationException,
+    match="unknown_field is declared on the factory PersonFactory but it is not part of the model Person",
+):
 
-
-def test_optional_type_ignored() -> None:
-    PersonFactory()
-    """
-    The above will raise:
-    polyfactory.exceptions.ConfigurationException: unknown_field is declared on the factory PersonFactory but it is not part of the model Person
-    """
+    class PersonFactory(DataclassFactory[Person]):
+        __model__ = Person
+        __check_model__ = True
+        unknown_field = PostGenerated(lambda: "foo")

--- a/docs/examples/configuration/test_example_8.py
+++ b/docs/examples/configuration/test_example_8.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from polyfactory import PostGenerated
+from polyfactory.factories.dataclass_factory import DataclassFactory
+
+
+@dataclass
+class Person:
+    id: UUID
+
+
+class PersonFactory(DataclassFactory[Person]):
+    __model__ = Person
+    __check_model__ = True
+    unknown_field = PostGenerated(lambda: "foo")
+
+
+def test_optional_type_ignored() -> None:
+    PersonFactory()
+    """
+    The above will raise:
+    polyfactory.exceptions.ConfigurationException: unknown_field is declared on the factory PersonFactory but it is not part of the model Person
+    """

--- a/docs/examples/configuration/test_example_8.py
+++ b/docs/examples/configuration/test_example_8.py
@@ -12,12 +12,13 @@ class Person:
     id: UUID
 
 
-with pytest.raises(
-    ConfigurationException,
-    match="unknown_field is declared on the factory PersonFactory but it is not part of the model Person",
-):
+def test_check_factory_fields() -> None:
+    with pytest.raises(
+        ConfigurationException,
+        match="unknown_field is declared on the factory PersonFactory but it is not part of the model Person",
+    ):
 
-    class PersonFactory(DataclassFactory[Person]):
-        __model__ = Person
-        __check_model__ = True
-        unknown_field = PostGenerated(lambda: "foo")
+        class PersonFactory(DataclassFactory[Person]):
+            __model__ = Person
+            __check_model__ = True
+            unknown_field = PostGenerated(lambda: "foo")

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -104,7 +104,7 @@ By setting to `False`, then optional types will always be treated as the wrapped
 
 Check Factory Fields
 --------------------
-When `__check_model__` is set to `True`, declaring an argument on the factory that doesn't exist on the model will trigger an exception.
+When `__check_model__` is set to `True`, declaring fields on the factory that don't exist on the model will trigger an exception.
 
 This is only true when fields are declared with ``Use``, ``PostGenerated``, ``Ignore`` and ``Require``.
 Any other field definition will not be checked.

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -101,3 +101,15 @@ By setting to `False`, then optional types will always be treated as the wrapped
 .. literalinclude:: /examples/configuration/test_example_7.py
     :caption: Disable Allow None Optionals
     :language: python
+
+Check Factory Fields
+--------------------
+When `__check_model__` is set to `True`, declaring an argument on the factory that doesn't exist on the model will trigger an exception.
+
+This is only true when fields are declared with ``Use``, ``PostGenerated``, ``Ignore`` and ``Require``.
+Any other field definition will not be checked.
+
+
+.. literalinclude:: /examples/configuration/test_example_8.py
+    :caption: Enable Check Factory Fields
+    :language: python

--- a/docs/usage/declaring_factories.rst
+++ b/docs/usage/declaring_factories.rst
@@ -38,6 +38,12 @@ Or for attrs models:
     Validators are not currently supported - neither the built in validators that come
     with `attrs` nor custom validators.
 
+.. note::
+    Declaring an argument on the factory that doesn't exist on the model will trigger an exception.
+
+    This is only true when fields are declared with ``Use``, ``PostGenerated``, ``Ignore`` and ``Require``,
+    any other field definition will not be checked.
+
 Imperative Factory Creation
 ---------------------------
 

--- a/docs/usage/declaring_factories.rst
+++ b/docs/usage/declaring_factories.rst
@@ -41,8 +41,8 @@ Or for attrs models:
 .. note::
     Declaring an argument on the factory that doesn't exist on the model will trigger an exception.
 
-    This is only true when fields are declared with ``Use``, ``PostGenerated``, ``Ignore`` and ``Require``,
-    any other field definition will not be checked.
+    This is only true when fields are declared with ``Use``, ``PostGenerated``, ``Ignore`` and ``Require``.
+    Any other field definition will not be checked.
 
 Imperative Factory Creation
 ---------------------------

--- a/docs/usage/declaring_factories.rst
+++ b/docs/usage/declaring_factories.rst
@@ -38,11 +38,6 @@ Or for attrs models:
     Validators are not currently supported - neither the built in validators that come
     with `attrs` nor custom validators.
 
-.. note::
-    Declaring an argument on the factory that doesn't exist on the model will trigger an exception.
-
-    This is only true when fields are declared with ``Use``, ``PostGenerated``, ``Ignore`` and ``Require``.
-    Any other field definition will not be checked.
 
 Imperative Factory Creation
 ---------------------------

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -668,6 +668,13 @@ class BaseFactory(ABC, Generic[T]):
 
     @classmethod
     def get_factory_fields(cls) -> list[tuple[str, Any]]:
+        """Retrieve a list of fields from the factory.
+
+        Trying to be smart about what should be considered a field on the model,
+        ignoring dunder methods and some parent class attributes.
+
+        :returns: A list of tuples made of field name and field definition
+        """
         factory_fields = cls.__dict__.items()
         return [
             (field_name, field_value)

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -184,7 +184,7 @@ class BaseFactory(ABC, Generic[T]):
             if not cls.is_supported_type(model):
                 for factory in BaseFactory._base_factories:
                     if factory.is_supported_type(model):
-                        msg = f"{cls.__name__} does not support {model.__name__}, but this type is support by the {factory.__name__} base factory class. To resolve this error, subclass the factory from {factory.__name__} instead of {cls.__name__}"
+                        msg = f"{cls.__name__} does not support {model.__name__}, but this type is supported by the {factory.__name__} base factory class. To resolve this error, subclass the factory from {factory.__name__} instead of {cls.__name__}"
                         raise ConfigurationException(
                             msg,
                         )

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -102,6 +102,11 @@ class BaseFactory(ABC, Generic[T]):
     The model for the factory.
     This attribute is required for non-base factories and an exception will be raised if its not set.
     """
+    __check_model__: bool = False
+    """
+    Flag dictating whether to check if fields defined on the factory exists on the model or not.
+    If 'True', checks will be done against Use, PostGenerated, Ignore, Require constructs fields only.
+    """
     __allow_none_optionals__: ClassVar[bool] = True
     """
     Flag dictating whether to allow 'None' for optional values.
@@ -192,7 +197,8 @@ class BaseFactory(ABC, Generic[T]):
                     raise ConfigurationException(
                         msg,
                     )
-            cls._check_declared_fields_exist_in_model()
+            if cls.__check_model__:
+                cls._check_declared_fields_exist_in_model()
         else:
             BaseFactory._base_factories.append(cls)
 

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from enum import EnumMeta
 from functools import partial
 from importlib import import_module
+import inspect
 from ipaddress import (
     IPv4Address,
     IPv4Interface,
@@ -36,6 +37,7 @@ from typing import (
     cast,
 )
 from uuid import UUID
+import warnings
 
 from faker import Faker
 from typing_extensions import get_args
@@ -81,6 +83,7 @@ from polyfactory.value_generators.primitives import (
     create_random_bytes,
     create_random_string,
 )
+from polyfactory.warning_categories import ConfigurationWarning
 
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
@@ -666,6 +669,34 @@ class BaseFactory(ABC, Generic[T]):
         raise NotImplementedError
 
     @classmethod
+    def get_factory_fields(cls) -> list[tuple[str, Any]]:
+        factory_fields = cls.__dict__.items()
+        return [
+            (field_name, field_value) for field_name, field_value in factory_fields
+            if not (field_name.startswith("__") or field_name == "_abc_impl")
+        ]
+
+
+    @classmethod
+    def _check_declared_fields_exist_in_model(cls):
+        model_fields_names = [field_meta.name for field_meta in cls.get_model_fields()]
+        factory_fields = cls.get_factory_fields()
+
+        for field_name, field_value in factory_fields:
+            if field_name in model_fields_names or inspect.isfunction(field_value):
+                continue
+            else:
+                error_message = (
+                    f"{field_name} is declared on the factory {cls.__name__}"
+                    f" but it is not part of the model {cls.__model__.__name__}"
+                )
+                if isinstance(field_value, (Use, PostGenerated, Ignore, Require)):
+                    raise ConfigurationException(error_message)
+                else:
+                    warnings.warn(ConfigurationWarning(error_message))
+
+
+    @classmethod
     def process_kwargs(cls, **kwargs: Any) -> dict[str, Any]:
         """Process the given kwargs and generate values for the factory's model.
 
@@ -676,7 +707,7 @@ class BaseFactory(ABC, Generic[T]):
         """
         result: dict[str, Any] = {**kwargs}
         generate_post: dict[str, PostGenerated] = {}
-
+        cls._check_declared_fields_exist_in_model()
         for field_meta in cls.get_model_fields():
             field_build_parameters = cls.extract_field_build_parameters(field_meta=field_meta, build_args=kwargs)
             if cls.should_set_field_value(field_meta, **kwargs):

--- a/polyfactory/warning_categories.py
+++ b/polyfactory/warning_categories.py
@@ -1,2 +1,0 @@
-class ConfigurationWarning(UserWarning):
-    """Configuration warning - used when a configuration might be wrong"""

--- a/polyfactory/warning_categories.py
+++ b/polyfactory/warning_categories.py
@@ -1,0 +1,2 @@
+class ConfigurationWarning(UserWarning):
+    """Configuration warning - used when a configuration might be wrong"""

--- a/tests/test_factory_fields.py
+++ b/tests/test_factory_fields.py
@@ -172,7 +172,27 @@ def test_post_generation_classmethod() -> None:
         Ignore(),
     ],
 )
-def test_non_existing_model_fields_raises(factory_field: Union[Use, PostGenerated, Require, Ignore]) -> None:
+def test_non_existing_model_fields_does_not_raise_by_default(
+    factory_field: Union[Use, PostGenerated, Require, Ignore],
+) -> None:
+    class NoFieldModel(BaseModel):
+        pass
+
+    ModelFactory.create_factory(NoFieldModel, bases=None, unknown_field=factory_field)
+
+
+@pytest.mark.parametrize(
+    "factory_field",
+    [
+        Use(lambda: "foo"),
+        PostGenerated(lambda: "foo"),
+        Require(),
+        Ignore(),
+    ],
+)
+def test_non_existing_model_fields_raises_with__check__model__(
+    factory_field: Union[Use, PostGenerated, Require, Ignore],
+) -> None:
     class NoFieldModel(BaseModel):
         pass
 
@@ -180,4 +200,4 @@ def test_non_existing_model_fields_raises(factory_field: Union[Use, PostGenerate
         ConfigurationException,
         match="unknown_field is declared on the factory NoFieldModelFactory but it is not part of the model NoFieldModel",
     ):
-        ModelFactory.create_factory(NoFieldModel, bases=None, unknown_field=factory_field)
+        ModelFactory.create_factory(NoFieldModel, bases=None, __check_model__=True, unknown_field=factory_field)

--- a/tests/test_factory_fields.py
+++ b/tests/test_factory_fields.py
@@ -1,6 +1,6 @@
 import random
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import pytest
 from pydantic import BaseModel
@@ -172,7 +172,7 @@ def test_post_generation_classmethod() -> None:
         Ignore(),
     ],
 )
-def test_non_existing_model_fields_raises(factory_field: Use | PostGenerated | Require | Ignore) -> None:
+def test_non_existing_model_fields_raises(factory_field: Union[Use, PostGenerated, Require, Ignore]) -> None:
     class NoFieldModel(BaseModel):
         pass
 

--- a/tests/test_factory_fields.py
+++ b/tests/test_factory_fields.py
@@ -180,4 +180,4 @@ def test_non_existing_model_fields_raises(factory_field: Union[Use, PostGenerate
         ConfigurationException,
         match="unknown_field is declared on the factory NoFieldModelFactory but it is not part of the model NoFieldModel",
     ):
-        ModelFactory.create_factory(NoFieldModel, bases=None, **{"unknown_field": factory_field})
+        ModelFactory.create_factory(NoFieldModel, bases=None, unknown_field=factory_field)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->
This change will detect whenever a field is defined on the factory that doesn't exist on the model.

- If the field is using an explicit construct (like `Use`, `PostGenerated`, ...) it will raise an exception
- in other case it will only output a warning
- classmethods / methods / functions and fields starting with `__`  are not checked because they can't be easily differentiated


### Close Issue(s)
Fixes #400
<!--
Please add in issue numbers this pull request will close, if applicable
Examples:  or Closes #1234
-->

- 
