### PR TITLE
fix: decouple the handling of collection length configuration from `FieldMeta`

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -279,10 +279,6 @@ class BaseFactory(ABC, Generic[T]):
         msg = f"unsupported model type {model.__name__}"
         raise ParameterException(msg)  # pragma: no cover
 
-    @classmethod
-    def _get_constrained_collection_field_meta(cls, field_meta: FieldMeta) -> None:
-        ...
-
     # Public Methods
 
     @classmethod

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -442,7 +442,7 @@ class BaseFactory(ABC, Generic[T]):
         )
 
     @classmethod
-    def get_constrained_field_value(cls, annotation: Any, field_meta: FieldMeta) -> Any:  # noqa: C901, PLR0911, PLR0912
+    def get_constrained_field_value(cls, annotation: Any, field_meta: FieldMeta) -> Any:  # noqa: C901, PLR0911
         try:
             constraints = cast("Constraints", field_meta.constraints)
             if is_safe_subclass(annotation, float):
@@ -491,7 +491,7 @@ class BaseFactory(ABC, Generic[T]):
                     pattern=constraints.get("pattern"),
                 )
 
-            try:
+            with suppress(ValueError):
                 collection_type = get_collection_type(annotation)
                 if collection_type == dict:
                     return handle_constrained_mapping(
@@ -510,9 +510,6 @@ class BaseFactory(ABC, Generic[T]):
                     min_items=constraints.get("min_length"),
                     unique_items=constraints.get("unique_items", False),
                 )
-            except ValueError:
-                # implies the annotation was not a collection type
-                pass
 
             if is_safe_subclass(annotation, date):
                 return handle_constrained_date(

--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -150,11 +150,7 @@ class FieldMeta:
         )
 
         if field.type_args and not field.children:
-            if randomize_collection_length:
-                number_of_args = random.randint(min_collection_length, max_collection_length)
-            else:
-                number_of_args = 1
-
+            number_of_args = 1
             extended_type_args = CollectionExtender.extend_type_args(field.annotation, field.type_args, number_of_args)
             field.children = [
                 FieldMeta.from_type(

--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Mapping
 
 from typing_extensions import get_args, get_origin
 
@@ -10,6 +10,7 @@ from polyfactory.utils.predicates import (
     is_annotated,
     is_new_type,
     is_optional,
+    is_safe_subclass,
     is_union,
 )
 
@@ -130,3 +131,26 @@ def normalize_annotation(annotation: Any, random: Random) -> Any:
         return origin[args] if origin is not type else annotation
 
     return origin
+
+
+def get_collection_type(annotation: Any) -> type[list | tuple | set | frozenset | dict]:
+    """Get the collection type from the annotation.
+
+    :param annotation: A type annotation.
+
+    :returns: The collection type.
+    """
+
+    if is_safe_subclass(annotation, list):
+        return list
+    if is_safe_subclass(annotation, Mapping):
+        return dict
+    if is_safe_subclass(annotation, tuple):
+        return tuple
+    if is_safe_subclass(annotation, set):
+        return set
+    if is_safe_subclass(annotation, frozenset):
+        return frozenset
+
+    msg = f"Unknown collection type - {annotation}"
+    raise ValueError(msg)

--- a/tests/test_attrs_factory.py
+++ b/tests/test_attrs_factory.py
@@ -1,7 +1,7 @@
 import datetime as dt
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Dict, FrozenSet, Generic, List, Set, Tuple, TypeVar
+from typing import Any, Dict, Generic, List, Tuple, TypeVar
 from uuid import UUID
 
 import attrs
@@ -133,61 +133,6 @@ def test_with_aliased_fields() -> None:
     foo = FooFactory.build()
 
     assert foo == Foo(foo.aliased)
-
-
-@pytest.mark.parametrize("type_", (Set, FrozenSet, List))
-def test_variable_length(type_: Any) -> None:
-    @define
-    class Foo:
-        items: type_[int]
-
-    class FooFactory(AttrsFactory[Foo]):
-        __model__ = Foo
-
-        __randomize_collection_length__ = True
-        number_of_args = 3
-
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    foo = FooFactory.build()
-    assert len(foo.items) == 3
-
-
-def test_variable_length__dict() -> None:
-    @define
-    class Foo:
-        items: Dict[int, float]
-
-    class FooFactory(AttrsFactory[Foo]):
-        __model__ = Foo
-
-        __randomize_collection_length__ = True
-        number_of_args = 3
-
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    foo = FooFactory.build()
-    assert len(foo.items) == 3
-
-
-def test_variable_length__tuple() -> None:
-    @define
-    class Foo:
-        items: Tuple[int, ...]
-
-    class FooFactory(AttrsFactory[Foo]):
-        __model__ = Foo
-
-        __randomize_collection_length__ = True
-        number_of_args = 3
-
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    foo = FooFactory.build()
-    assert len(foo.items) == 3
 
 
 def test_with_generics() -> None:

--- a/tests/test_beanie_factory.py
+++ b/tests/test_beanie_factory.py
@@ -80,18 +80,3 @@ async def test_beanie_persistence_of_multiple_instances(beanie_init: Callable) -
 async def test_beanie_links(beanie_init: Callable) -> None:
     result = await MyOtherFactory.create_async()
     assert isinstance(result.document, MyDocument)
-
-
-def test_variable_length(beanie_init: Callable) -> None:
-    class MyVariableFactory(BeanieDocumentFactory):
-        __model__ = MyDocument
-
-        __randomize_collection_length__ = True
-        number_of_args = 3
-
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyVariableFactory.build()
-
-    assert len(result.siblings) == 3

--- a/tests/test_collection_length.py
+++ b/tests/test_collection_length.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Set, Tuple
+
 import pytest
 from pydantic.dataclasses import dataclass
 
@@ -6,7 +8,7 @@ from polyfactory.factories import DataclassFactory
 MIN_MAX_PARAMETERS = ((10, 15), (20, 25), (30, 40), (40, 50))
 
 
-@pytest.mark.parametrize("type_", (list, set))
+@pytest.mark.parametrize("type_", (List, Set))
 @pytest.mark.parametrize(("min_val", "max_val"), MIN_MAX_PARAMETERS)
 def test_collection_length_with_list(min_val: int, max_val: int, type_: type) -> None:
     @dataclass
@@ -29,7 +31,7 @@ def test_collection_length_with_list(min_val: int, max_val: int, type_: type) ->
 def test_collection_length_with_tuple(min_val: int, max_val: int) -> None:
     @dataclass
     class Foo:
-        foo: tuple[int, ...]
+        foo: Tuple[int, ...]
 
     class FooFactory(DataclassFactory[Foo]):
         __model__ = Foo
@@ -47,7 +49,7 @@ def test_collection_length_with_tuple(min_val: int, max_val: int) -> None:
 def test_collection_length_with_dict(min_val: int, max_val: int) -> None:
     @dataclass
     class Foo:
-        foo: dict[int, int]
+        foo: Dict[int, int]
 
     class FooFactory(DataclassFactory[Foo]):
         __model__ = Foo
@@ -66,7 +68,7 @@ def test_collection_length_with_dict(min_val: int, max_val: int) -> None:
 def test_collection_length_with_optional_not_allowed(min_val: int, max_val: int) -> None:
     @dataclass
     class Foo:
-        foo: list[int] | None
+        foo: List[int] | None
 
     class FooFactory(DataclassFactory[Foo]):
         __model__ = Foo
@@ -87,7 +89,7 @@ def test_collection_length_with_optional_not_allowed(min_val: int, max_val: int)
 def test_collection_length_with_optional_allowed(min_val: int, max_val: int) -> None:
     @dataclass
     class Foo:
-        foo: list[int] | None
+        foo: List[int] | None
 
     class FooFactory(DataclassFactory[Foo]):
         __model__ = Foo

--- a/tests/test_collection_length.py
+++ b/tests/test_collection_length.py
@@ -1,0 +1,106 @@
+import pytest
+from pydantic.dataclasses import dataclass
+
+from polyfactory.factories import DataclassFactory
+
+MIN_MAX_PARAMETERS = ((10, 15), (20, 25), (30, 40), (40, 50))
+
+
+@pytest.mark.parametrize("type_", (list, set))
+@pytest.mark.parametrize(("min_val", "max_val"), MIN_MAX_PARAMETERS)
+def test_collection_length_with_list(min_val: int, max_val: int, type_: type) -> None:
+    @dataclass
+    class Foo:
+        foo: type_[int]  # type: ignore
+
+    class FooFactory(DataclassFactory[Foo]):
+        __model__ = Foo
+        __randomize_collection_length__ = True
+        __min_collection_length__ = min_val
+        __max_collection_length__ = max_val
+
+    foo = FooFactory.build()
+
+    assert len(foo.foo) >= min_val, len(foo.foo)
+    assert len(foo.foo) <= max_val, len(foo.foo)
+
+
+@pytest.mark.parametrize(("min_val", "max_val"), MIN_MAX_PARAMETERS)
+def test_collection_length_with_tuple(min_val: int, max_val: int) -> None:
+    @dataclass
+    class Foo:
+        foo: tuple[int, ...]
+
+    class FooFactory(DataclassFactory[Foo]):
+        __model__ = Foo
+        __randomize_collection_length__ = True
+        __min_collection_length__ = min_val
+        __max_collection_length__ = max_val
+
+    foo = FooFactory.build()
+
+    assert len(foo.foo) >= min_val, len(foo.foo)
+    assert len(foo.foo) <= max_val, len(foo.foo)
+
+
+@pytest.mark.parametrize(("min_val", "max_val"), MIN_MAX_PARAMETERS)
+def test_collection_length_with_dict(min_val: int, max_val: int) -> None:
+    @dataclass
+    class Foo:
+        foo: dict[int, int]
+
+    class FooFactory(DataclassFactory[Foo]):
+        __model__ = Foo
+
+        __randomize_collection_length__ = True
+        __min_collection_length__ = min_val
+        __max_collection_length__ = max_val
+
+    foo = FooFactory.build()
+
+    assert len(foo.foo) >= min_val, len(foo.foo)
+    assert len(foo.foo) <= max_val, len(foo.foo)
+
+
+@pytest.mark.parametrize(("min_val", "max_val"), MIN_MAX_PARAMETERS)
+def test_collection_length_with_optional_not_allowed(min_val: int, max_val: int) -> None:
+    @dataclass
+    class Foo:
+        foo: list[int] | None
+
+    class FooFactory(DataclassFactory[Foo]):
+        __model__ = Foo
+
+        __allow_none_optionals__ = False
+        __randomize_collection_length__ = True
+        __min_collection_length__ = min_val
+        __max_collection_length__ = max_val
+
+    foo = FooFactory.build()
+
+    assert foo.foo is not None
+    assert len(foo.foo) >= min_val, len(foo.foo)
+    assert len(foo.foo) <= max_val, len(foo.foo)
+
+
+@pytest.mark.parametrize(("min_val", "max_val"), MIN_MAX_PARAMETERS)
+def test_collection_length_with_optional_allowed(min_val: int, max_val: int) -> None:
+    @dataclass
+    class Foo:
+        foo: list[int] | None
+
+    class FooFactory(DataclassFactory[Foo]):
+        __model__ = Foo
+
+        __randomize_collection_length__ = True
+        __min_collection_length__ = min_val
+        __max_collection_length__ = max_val
+
+    for _ in range(10):
+        foo = FooFactory.build()
+
+        if foo.foo is None:
+            continue
+
+        assert len(foo.foo) >= min_val, len(foo.foo)
+        assert len(foo.foo) <= max_val, len(foo.foo)

--- a/tests/test_collection_length.py
+++ b/tests/test_collection_length.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import pytest
 from pydantic.dataclasses import dataclass
@@ -68,7 +68,7 @@ def test_collection_length_with_dict(min_val: int, max_val: int) -> None:
 def test_collection_length_with_optional_not_allowed(min_val: int, max_val: int) -> None:
     @dataclass
     class Foo:
-        foo: List[int] | None
+        foo: Optional[List[int]]
 
     class FooFactory(DataclassFactory[Foo]):
         __model__ = Foo
@@ -89,7 +89,7 @@ def test_collection_length_with_optional_not_allowed(min_val: int, max_val: int)
 def test_collection_length_with_optional_allowed(min_val: int, max_val: int) -> None:
     @dataclass
     class Foo:
-        foo: List[int] | None
+        foo: Optional[List[int]]
 
     class FooFactory(DataclassFactory[Foo]):
         __model__ = Foo

--- a/tests/test_dataclass_factory.py
+++ b/tests/test_dataclass_factory.py
@@ -4,7 +4,6 @@ from types import ModuleType
 from typing import Callable, Dict, List, Optional, Tuple
 from unittest.mock import ANY
 
-from pydantic.dataclasses import Field  # type: ignore
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from polyfactory.factories import DataclassFactory
@@ -38,7 +37,6 @@ def test_factory_pydantic_dc() -> None:
         id: int
         name: str
         list_field: List[Dict[str, int]]
-        constrained_field: int = Field(ge=100)
         field_of_some_value: Optional[int] = field(default_factory=lambda: 0)
 
     class MyFactory(DataclassFactory[PydanticDC]):
@@ -52,7 +50,6 @@ def test_factory_pydantic_dc() -> None:
     assert result.list_field
     assert result.list_field[0]
     assert [isinstance(value, int) for value in result.list_field[0].values()]
-    assert result.constrained_field >= 100
 
 
 def test_vanilla_dc_with_embedded_model() -> None:

--- a/tests/test_dataclass_factory.py
+++ b/tests/test_dataclass_factory.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass as vanilla_dataclass
 from dataclasses import field
 from types import ModuleType
-from typing import Callable, Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 from unittest.mock import ANY
 
 from pydantic.dataclasses import Field  # type: ignore
@@ -195,87 +195,3 @@ class Bar:
 
     foo = FooFactory.build()
     assert isinstance(foo, Foo)
-
-
-def test_variable_length_tuple_generation__many_type_args() -> None:
-    @vanilla_dataclass
-    class VanillaDC:
-        ids: Tuple[int, ...]
-
-    number_of_args = 3
-
-    class MyFactory(DataclassFactory[VanillaDC]):
-        __model__ = VanillaDC
-
-        __randomize_collection_length__ = True
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyFactory.build()
-
-    assert result
-    assert result.ids
-    assert len(result.ids) == number_of_args
-
-
-def test_variable_length_dict_generation__many_type_args() -> None:
-    @vanilla_dataclass
-    class VanillaDC:
-        ids: Dict[str, int]
-
-    number_of_args = 3
-
-    class MyFactory(DataclassFactory[VanillaDC]):
-        __model__ = VanillaDC
-
-        __randomize_collection_length__ = True
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyFactory.build()
-
-    assert result
-    assert result.ids
-    assert len(result.ids) == number_of_args
-
-
-def test_variable_length_list_generation__many_type_args() -> None:
-    @vanilla_dataclass
-    class VanillaDC:
-        ids: List[int]
-
-    number_of_args = 3
-
-    class MyFactory(DataclassFactory[VanillaDC]):
-        __model__ = VanillaDC
-
-        __randomize_collection_length__ = True
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyFactory.build()
-
-    assert result
-    assert result.ids
-    assert len(result.ids) == number_of_args
-
-
-def test_variable_length_set_generation__many_type_args() -> None:
-    @vanilla_dataclass
-    class VanillaDC:
-        ids: Set[int]
-
-    number_of_args = 3
-
-    class MyFactory(DataclassFactory[VanillaDC]):
-        __model__ = VanillaDC
-
-        __randomize_collection_length__ = True
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyFactory.build()
-
-    assert result
-    assert result.ids
-    assert len(result.ids) == number_of_args

--- a/tests/test_msgspec_factory.py
+++ b/tests/test_msgspec_factory.py
@@ -180,58 +180,6 @@ def test_datetime_constraints(t: Union[Type[dt.datetime], Type[dt.time]]) -> Non
         _ = FooFactory.build()
 
 
-@pytest.mark.parametrize("type_", (Set, FrozenSet, List))
-def test_variable_length(type_: Any) -> None:
-    class Foo(Struct):
-        items: type_[int]
-
-    class FooFactory(MsgspecFactory[Foo]):
-        __model__ = Foo
-
-        __randomize_collection_length__ = True
-        number_of_args = 3
-
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    foo = FooFactory.build()
-    assert len(foo.items) == 3
-
-
-def test_variable_length__dict() -> None:
-    class Foo(Struct):
-        items: Dict[int, float]
-
-    class FooFactory(MsgspecFactory[Foo]):
-        __model__ = Foo
-
-        __randomize_collection_length__ = True
-        number_of_args = 3
-
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    foo = FooFactory.build()
-    assert len(foo.items) == 3
-
-
-def test_variable_length__tuple() -> None:
-    class Foo(Struct):
-        items: Tuple[int, ...]
-
-    class FooFactory(MsgspecFactory[Foo]):
-        __model__ = Foo
-
-        __randomize_collection_length__ = True
-        number_of_args = 3
-
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    foo = FooFactory.build()
-    assert len(foo.items) == 3
-
-
 def test_inheritence() -> None:
     class Foo(Struct):
         int_field: int

--- a/tests/test_odmantic_factory.py
+++ b/tests/test_odmantic_factory.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, FrozenSet, List, Set, Tuple
+from typing import Any, List
 from uuid import UUID
 
 import bson
@@ -101,59 +101,3 @@ def test_post_generated_from_id() -> None:
             return f"{cls.__faker__.name()} [{id.generation_time}]"
 
     MyFactory.build()
-
-
-@pytest.mark.parametrize("type_", (Set, FrozenSet, List))
-def test_variable_length(type_: Any) -> None:
-    class MyModel(Model):  # type: ignore
-        items: type_[bson.Int64]
-
-    class MyFactory(OdmanticModelFactory[MyModel]):
-        __model__ = MyModel
-
-        __randomize_collection_length__ = True
-        number_of_args = 3
-
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyFactory.build()
-
-    assert len(result.items) == 3
-
-
-@pytest.mark.skipif(True, reason="test is flaky - refer issue #362")
-def test_variable_length__dict() -> None:
-    class MyModel(Model):  # type: ignore
-        items: Dict[bson.Int64, UUID]
-
-    class MyFactory(OdmanticModelFactory[MyModel]):
-        __model__ = MyModel
-
-        __randomize_collection_length__ = True
-        number_of_args = 3
-
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyFactory.build()
-
-    assert len(result.items) == 3
-
-
-def test_variable_length__tuple() -> None:
-    class MyModel(Model):  # type: ignore
-        items: Tuple[bson.Int64, ...]
-
-    class MyFactory(OdmanticModelFactory[MyModel]):
-        __model__ = MyModel
-
-        __randomize_collection_length__ = True
-        number_of_args = 3
-
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyFactory.build()
-
-    assert len(result.items) == 3

--- a/tests/test_passing_build_args_to_child_factories.py
+++ b/tests/test_passing_build_args_to_child_factories.py
@@ -1,6 +1,5 @@
-from typing import Any, Dict, FrozenSet, List, Mapping, Optional, Set, Tuple
+from typing import List, Mapping, Optional
 
-import pytest
 from pydantic import BaseModel
 
 from polyfactory.factories.pydantic_factory import ModelFactory
@@ -177,67 +176,3 @@ def test_factory_with_partial_kwargs_deep_in_tree() -> None:
     build_result = DFactory.build(factory_use_construct=False, **{"c": {"b": {"a": {"name": "test"}}}})
     assert build_result
     assert build_result.c.b.a.name == "test"
-
-
-@pytest.mark.parametrize("type_", (Set, FrozenSet, List))
-def test_variable_length__collection(type_: Any) -> None:
-    class Vanilla(BaseModel):
-        ids: type_[int]
-
-    number_of_args = 3
-
-    class MyFactory(ModelFactory[Vanilla]):
-        __model__ = Vanilla
-
-        __randomize_collection_length__ = True
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyFactory.build()
-
-    assert result
-    assert result.ids
-    assert len(result.ids) == number_of_args
-
-
-def test_variable_length__tuple() -> None:
-    class Chocolate(BaseModel):
-        val: float
-
-    class Vanilla(BaseModel):
-        ids: Tuple[Chocolate, ...]
-
-    number_of_args = 3
-
-    class MyFactory(ModelFactory[Vanilla]):
-        __model__ = Vanilla
-
-        __randomize_collection_length__ = True
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyFactory.build()
-
-    assert result
-    assert result.ids
-    assert len(result.ids) == number_of_args
-
-
-def test_variable_length__dict() -> None:
-    class Vanilla(BaseModel):
-        ids: Dict[str, float]
-
-    number_of_args = 3
-
-    class MyFactory(ModelFactory[Vanilla]):
-        __model__ = Vanilla
-
-        __randomize_collection_length__ = True
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyFactory.build()
-
-    assert result
-    assert result.ids
-    assert len(result.ids) == number_of_args

--- a/tests/test_typeddict_factory.py
+++ b/tests/test_typeddict_factory.py
@@ -44,21 +44,3 @@ def test_factory_model_with_typeddict_attribute_value() -> None:
     assert result.td["name"]
     assert result.td["list_field"][0]
     assert type(result.td["int_field"]) in (type(None), int)
-
-
-def test_variable_length() -> None:
-    class MyModel(BaseModel):
-        items: List[int]
-
-    class MyFactory(ModelFactory[MyModel]):
-        __model__ = MyModel
-
-        __randomize_collection_length__ = True
-        number_of_args = 3
-
-        __min_collection_length__ = number_of_args
-        __max_collection_length__ = number_of_args
-
-    result = MyFactory.build()
-
-    assert len(result.items) == 3


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- this handles the cases where `__min_collection_length__` or `__max_collection_length__` are set in the `get_field_value` method directly instead of coupling these constraints into the created `FieldMeta` instances

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Fixes #403 
