### PR TITLE
fix: respect override of optional nested model fields

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -559,7 +559,7 @@ class BaseFactory(ABC, Generic[T]):
         if cls.is_ignored_type(field_meta.annotation):
             return None
 
-        if cls.should_set_none_value(field_meta=field_meta):
+        if field_build_parameters is None and cls.should_set_none_value(field_meta=field_meta):
             return None
 
         unwrapped_annotation = unwrap_annotation(field_meta.annotation, random=cls.__random__)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -40,6 +40,21 @@ def test_respects_none_overrides() -> None:
     assert result.hobbies is None
 
 
+def test_allows_nested_optional_field_overrides() -> None:
+    class MyChildModel(BaseModel):
+        name: str
+
+    class MyParentModel(BaseModel):
+        child: MyChildModel | None
+
+    class MyParentModelFactory(ModelFactory):
+        __model__ = MyParentModel
+
+    MyParentModelFactory.seed_random(2)
+    result = MyParentModelFactory.build(child={"name": "test"})
+    assert result.child is not None
+
+
 def test_uses_faker_to_set_values_when_none_available_on_class() -> None:
     result = PetFactory.build()
     assert isinstance(result.name, str)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -40,21 +40,6 @@ def test_respects_none_overrides() -> None:
     assert result.hobbies is None
 
 
-def test_allows_nested_optional_field_overrides() -> None:
-    class MyChildModel(BaseModel):
-        name: str
-
-    class MyParentModel(BaseModel):
-        child: MyChildModel | None
-
-    class MyParentModelFactory(ModelFactory):
-        __model__ = MyParentModel
-
-    MyParentModelFactory.seed_random(2)
-    result = MyParentModelFactory.build(child={"name": "test"})
-    assert result.child is not None
-
-
 def test_uses_faker_to_set_values_when_none_available_on_class() -> None:
     result = PetFactory.build()
     assert isinstance(result.name, str)

--- a/tests/test_passing_build_args_to_child_factories.py
+++ b/tests/test_passing_build_args_to_child_factories.py
@@ -3,6 +3,7 @@ from typing import List, Mapping, Optional
 from pydantic import BaseModel
 
 from polyfactory.factories.pydantic_factory import ModelFactory
+from polyfactory.field_meta import FieldMeta
 
 
 class Address(BaseModel):
@@ -188,6 +189,9 @@ def test_factory_with_nested_optional_field_overrides_in_dict() -> None:
     class MyParentModelFactory(ModelFactory):
         __model__ = MyParentModel
 
-    MyParentModelFactory.seed_random(2)
+        @classmethod
+        def should_set_none_value(cls, field_meta: FieldMeta) -> bool:
+            return True
+
     result = MyParentModelFactory.build(child={"name": "test"})
     assert result.child is not None

--- a/tests/test_passing_build_args_to_child_factories.py
+++ b/tests/test_passing_build_args_to_child_factories.py
@@ -183,7 +183,7 @@ def test_factory_with_nested_optional_field_overrides_in_dict() -> None:
         name: str
 
     class MyParentModel(BaseModel):
-        child: MyChildModel | None
+        child: Optional[MyChildModel]
 
     class MyParentModelFactory(ModelFactory):
         __model__ = MyParentModel

--- a/tests/test_passing_build_args_to_child_factories.py
+++ b/tests/test_passing_build_args_to_child_factories.py
@@ -195,3 +195,4 @@ def test_factory_with_nested_optional_field_overrides_in_dict() -> None:
 
     result = MyParentModelFactory.build(child={"name": "test"})
     assert result.child is not None
+    assert result.child.name == "test"

--- a/tests/test_passing_build_args_to_child_factories.py
+++ b/tests/test_passing_build_args_to_child_factories.py
@@ -176,3 +176,18 @@ def test_factory_with_partial_kwargs_deep_in_tree() -> None:
     build_result = DFactory.build(factory_use_construct=False, **{"c": {"b": {"a": {"name": "test"}}}})
     assert build_result
     assert build_result.c.b.a.name == "test"
+
+
+def test_factory_with_nested_optional_field_overrides_in_dict() -> None:
+    class MyChildModel(BaseModel):
+        name: str
+
+    class MyParentModel(BaseModel):
+        child: MyChildModel | None
+
+    class MyParentModelFactory(ModelFactory):
+        __model__ = MyParentModel
+
+    MyParentModelFactory.seed_random(2)
+    result = MyParentModelFactory.build(child={"name": "test"})
+    assert result.child is not None


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- Fixes `None` being randomly assigned to optional fields whose type is another model even if attributes for that model are passed to `build` as a `dict`

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Closes #419

---

I tried to mimic the structure of other tests on the file but open to feedback. The code change makes sense to me (if there are build parameters defined for a given field, don't consider setting it to `None`) but there might be other code paths I'm not considering.