### PR TITLE
feat: autofill `model` argument when calling `create_factory` with receiving factory `__model__`

### DIFF
--- a/docs/examples/declaring_factories/test_example_8.py
+++ b/docs/examples/declaring_factories/test_example_8.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from enum import Enum
+
+from polyfactory.factories import DataclassFactory
+
+
+class Species(str, Enum):
+    CAT = "Cat"
+    DOG = "Dog"
+    RABBIT = "Rabbit"
+    MOUSE = "Mouse"
+
+
+@dataclass
+class Pet:
+    name: str
+    species: Species
+    sound: str
+
+
+def test_imperative_sub_factory_creation() -> None:
+    pet_factory = DataclassFactory.create_factory(model=Pet)
+    cat_factory = pet_factory.create_factory(species=Species.CAT)
+    cat_instance = cat_factory.build()
+
+    assert isinstance(cat_instance, Pet)
+    assert cat_instance.species == Species.CAT

--- a/docs/usage/declaring_factories.rst
+++ b/docs/usage/declaring_factories.rst
@@ -56,3 +56,11 @@ You can also use this method to create factories imperatively:
 .. literalinclude:: /examples/declaring_factories/test_example_6.py
     :caption: Imperative factory creation
     :language: python
+
+Eventually you can use this method on an existing concrete factory to create a sub factory overriding some parent configuration:
+
+.. literalinclude:: /examples/declaring_factories/test_example_8.py
+    :caption: Imperative sub factory creation
+    :language: python
+
+In this case you don't need to specify the `model` argument to the :meth:`create_factory <polyfactory.factories.base.BaseFactory.create_factory>` method. The one from the parent factory will be used.

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -440,12 +440,12 @@ class BaseFactory(ABC, Generic[T]):
         :returns: A 'ModelFactory' subclass.
 
         """
-        with suppress(AttributeError):
-            model = model or cls.__model__
         if model is None:
-            msg = "A 'model' argument is required when creating a new factory from a base one"
-            raise TypeError(msg)
-
+            try:
+                model = cls.__model__
+            except AttributeError as ex:
+                msg = "A 'model' argument is required when creating a new factory from a base one"
+                raise TypeError(msg) from ex
         return cast(
             "Type[F]",
             type(

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -426,7 +426,7 @@ class BaseFactory(ABC, Generic[T]):
     @classmethod
     def create_factory(
         cls: type[F],
-        model: type[T],
+        model: type[T] | None = None,
         bases: tuple[type[BaseFactory[Any]], ...] | None = None,
         **kwargs: Any,
     ) -> type[F]:
@@ -439,6 +439,12 @@ class BaseFactory(ABC, Generic[T]):
         :returns: A 'ModelFactory' subclass.
 
         """
+        with suppress(AttributeError):
+            model = model or cls.__model__
+        if model is None:
+            msg = "A 'model' argument is required when creating a new factory from a base one"
+            raise TypeError(msg)
+
         return cast(
             "Type[F]",
             type(

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -432,7 +432,8 @@ class BaseFactory(ABC, Generic[T]):
     ) -> type[F]:
         """Generate a factory for the given type dynamically.
 
-        :param model: A type to model.
+        :param model: A type to model. Defaults to current factory __model__ if any.
+            Otherwise, raise an error
         :param bases: Base classes to use when generating the new class.
         :param kwargs: Any kwargs.
 

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -449,7 +449,7 @@ class BaseFactory(ABC, Generic[T]):
         return cast(
             "Type[F]",
             type(
-                f"{model.__name__}Factory",
+                f"{model.__name__}Factory",  # pyright: ignore[reportOptionalMemberAccess]
                 (*(bases or ()), cls),
                 {"__model__": model, **kwargs},
             ),

--- a/tests/test_base_factories.py
+++ b/tests/test_base_factories.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic.main import BaseModel
 
 from polyfactory.factories import DataclassFactory
+from polyfactory.factories.base import BaseFactory
 from polyfactory.factories.pydantic_factory import ModelFactory
 
 
@@ -78,3 +79,19 @@ def test_multiple_base_pydantic_factories(override_BaseModel: bool) -> None:
     # see https://github.com/litestar-org/polyfactory/issues/198
     ModelFactory._base_factories.remove(FooModelFactory)
     ModelFactory._base_factories.remove(DummyModelFactory)
+
+
+def test_create_factory_without_model_reuse_current_factory_model() -> None:
+    @dataclass
+    class Foo:
+        pass
+
+    factory = DataclassFactory.create_factory(model=Foo)
+    sub_factory = factory.create_factory()
+
+    assert sub_factory.__model__ == Foo
+
+
+def test_create_factory_from_base_factory_without_providing_a_model_raises_error() -> None:
+    with pytest.raises(TypeError):
+        BaseFactory.create_factory()


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [X] New code has 100% test coverage
- [X] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [X] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [X] Pre-Commit Checks were ran and passed
- [X] Tests were ran and passed

### Description

This PR aims at allowing to create "sub" factories from concrete factories (i.e: a factory with a `__model__` set) without having to pass the `model` argument to the `create_factory` method.

In this case, when the `model` argument is omitted, the `__model__` of the receiving factory will be used by default, increasing code readability and making the dynamic mode working the same way as the imperative style.

>The PR includes the change, the tests and the documentation update.

```python
from dataclasses import dataclass

from polyfactory.factories import DataclassFactory

@dataclass
class Foo:
    bar: str

# Imperative mode
class FooFactory(DataclassFactory):
    __model__ = Foo

class BarFactory(FooFactory):
    bar = "bar"

# Dynamic mode (after this PR)
foo_factory = DataclassFactory.create_factory(Foo)
bar_factory = foo_factory.create_factory(bar="bar")
```

### Close Issue(s)
Closes #357 