### PR TITLE
fix: handle cases where 'init=False' for dataclasses and attrs models

### DIFF
--- a/polyfactory/factories/attrs_factory.py
+++ b/polyfactory/factories/attrs_factory.py
@@ -43,6 +43,9 @@ class AttrsFactory(Generic[T], BaseFactory[T]):
         fields = attrs.fields(cls.__model__)
 
         for field in fields:
+            if not field.init:
+                continue
+
             annotation = none_type if field.type is None else field.type
 
             default = field.default

--- a/polyfactory/factories/dataclass_factory.py
+++ b/polyfactory/factories/dataclass_factory.py
@@ -36,6 +36,9 @@ class DataclassFactory(Generic[T], BaseFactory[T]):
         model_type_hints = get_type_hints(cls.__model__, include_extras=True)
 
         for field in fields(cls.__model__):  # type: ignore[arg-type]
+            if not field.init:
+                continue
+
             if field.default_factory and field.default_factory is not MISSING:
                 default_value = field.default_factory()
             elif field.default is not MISSING:

--- a/tests/test_attrs_factory.py
+++ b/tests/test_attrs_factory.py
@@ -180,3 +180,14 @@ def test_with_stringified_annotations() -> None:
     foo = FooFactory.build()
 
     assert isinstance(foo.int_field, int)
+
+
+def test_with_init_false() -> None:
+    @define
+    class Foo:
+        foo: int = attrs.field(init=False)
+
+    class FooFactory(AttrsFactory[Foo]):
+        __model__ = Foo
+
+    assert FooFactory.build()

--- a/tests/test_dataclass_factory.py
+++ b/tests/test_dataclass_factory.py
@@ -192,3 +192,16 @@ class Bar:
 
     foo = FooFactory.build()
     assert isinstance(foo, Foo)
+
+
+def test_dataclass_with_init_false() -> None:
+    @vanilla_dataclass
+    class VanillaDC:
+        id_: int = field(init=False)
+
+    class MyFactory(DataclassFactory[VanillaDC]):
+        __model__ = VanillaDC
+
+    result = MyFactory.build()
+
+    assert result


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- This PR checks if the `init` value is set to `False` for dataclasses and attrs models before creating the field metas

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Fixes #416
