### PR TITLE
fix: flatten_annotation behaviour for Optional

### DIFF
--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -94,8 +94,8 @@ def flatten_annotation(annotation: Any) -> list[Any]:
     if is_new_type(annotation):
         flat.extend(flatten_annotation(unwrap_new_type(annotation)))
     elif is_optional(annotation):
-        flat.append(NoneType)
-        flat.extend(flatten_annotation(arg) for arg in get_args(annotation) if arg not in (NoneType, None))
+        for a in get_args(annotation):
+            flat.extend(flatten_annotation(a))
     elif is_annotated(annotation):
         flat.extend(flatten_annotation(get_args(annotation)[0]))
     elif is_union(annotation):

--- a/tests/test_type_coverage_generation.py
+++ b/tests/test_type_coverage_generation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, make_dataclass
 from datetime import date
-from typing import Dict, FrozenSet, List, Literal, Set, Tuple, Union
+from typing import Dict, FrozenSet, List, Literal, Optional, Set, Tuple, Union
 from uuid import UUID
 
 import pytest
@@ -212,3 +212,18 @@ def test_coverage_parameter_exception() -> None:
 
     with pytest.raises(ParameterException):
         list(Factory.coverage())
+
+
+def test_coverage_optional_field() -> None:
+    @dataclass
+    class OptionalInt:
+        i: Optional[int]
+
+    class OptionalIntFactory(DataclassFactory[OptionalInt]):
+        __model__ = OptionalInt
+
+    results = list(OptionalIntFactory.coverage())
+    assert len(results) == 2
+
+    assert isinstance(results[0].i, int)
+    assert results[1].i is None


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [x] Pre-Commit Checks were ran and passed
- [x] Tests were ran and passed

### Description
`polyfactoryutils.helpers.flatten_annotation` does not handle Optional properly


### Close Issue(s)
Fixes: #439 