### PR TITLE
fix: don't blindly suppress ValueError

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -492,7 +492,7 @@ class BaseFactory(ABC, Generic[T]):
         )
 
     @classmethod
-    def get_constrained_field_value(cls, annotation: Any, field_meta: FieldMeta) -> Any:  # noqa: C901, PLR0911
+    def get_constrained_field_value(cls, annotation: Any, field_meta: FieldMeta) -> Any:  # noqa: C901, PLR0911, PLR0912
         try:
             constraints = cast("Constraints", field_meta.constraints)
             if is_safe_subclass(annotation, float):
@@ -541,8 +541,11 @@ class BaseFactory(ABC, Generic[T]):
                     pattern=constraints.get("pattern"),
                 )
 
-            with suppress(ValueError):
+            try:
                 collection_type = get_collection_type(annotation)
+            except ValueError:
+                collection_type = None
+            if collection_type is not None:
                 if collection_type == dict:
                     return handle_constrained_mapping(
                         factory=cls,
@@ -550,7 +553,6 @@ class BaseFactory(ABC, Generic[T]):
                         min_items=constraints.get("min_length"),
                         max_items=constraints.get("max_length"),
                     )
-
                 return handle_constrained_collection(
                     collection_type=collection_type,  # type: ignore[type-var]
                     factory=cls,


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

The suppressing of `ValueError` even when it's raised from `get_constrained_collection` or `get_constrained_dict` causes the exception to be thrown to be misleading. This fixes that by only catching the `ValueError` if it was raised from `get_collection_type`.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Fixes #449.
