### PR TITLE
fix: add min version to typing-extensions

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "msgspec", "sqlalchemy", "lint", "attrs", "full", "docs", "odmantic", "pydantic", "test", "dev", "beanie"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:fdbe2e08c7fa2713913bf0f53e45ac79993264869568e92094eb4acebedf6274"
+content_hash = "sha256:8e11d212169bbcf04b0ad0f5d83338be63e8054ec878487d573051b7a97abb19"
 
 [[package]]
 name = "accessible-pygments"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ license = {text = "MIT"}
 requires-python = ">=3.8,<4.0"
 dependencies = [
     "faker",
-    "typing-extensions >= 4.6.0",
+    "typing-extensions>=4.6.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ license = {text = "MIT"}
 requires-python = ">=3.8,<4.0"
 dependencies = [
     "faker",
-    "typing-extensions",
+    "typing-extensions >= 4.6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
Add minimum `typing-extensions` version in dependencies.

### Close Issue(s)
Closes #470