### PR TITLE
feat: allow use of the default value based on configuration

### DIFF
--- a/docs/examples/configuration/test_example_9.py
+++ b/docs/examples/configuration/test_example_9.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from enum import Enum
+
+from polyfactory.factories import DataclassFactory
+
+
+class Species(str, Enum):
+    CAT = "Cat"
+    DOG = "Dog"
+
+
+@dataclass
+class Pet:
+    name: str
+    sound: str = "meow"
+    species: Species = Species.CAT
+
+
+class PetFactory(DataclassFactory[Pet]):
+    __model__ = Pet
+    __use_defaults__ = True
+
+
+def test_use_default() -> None:
+    pet = PetFactory.build()
+
+    assert pet.species == Species.CAT
+    assert pet.sound == "meow"

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -121,7 +121,7 @@ If ``__use_default__`` is set to ``True``, then the default value will be used i
 for a given field, provided there's a default value for that field.
 
 By default, ``__use_default__`` is set to ``False.`` If you need more fine grained control, you can override the
-:meth:`BaseFactory <polyfactory.factories.base.BaseFactory.should_use_default_value>` classmethod.
+:meth:`~polyfactory.factories.base.BaseFactory.should_use_default_value` classmethod.
 
 .. note::
     Setting ``__use_default__`` has no effect for ``TypedDictFactory`` since you cannot set default values for

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -123,6 +123,9 @@ for a given field, provided there's a default value for that field.
 By default, ``__use_default__`` is set to ``False.`` If you need more fine grained control, you can override the
 :meth:`BaseFactory <polyfactory.factories.base.BaseFactory.should_use_default_value>` classmethod.
 
+.. note::
+    Setting ``__use_default__`` has no effect for ``TypedDictFactory`` since you cannot set default values for
+    ``TypedDict``.
 
 .. literalinclude:: /examples/configuration/test_example_9.py
     :caption: Use Default Values

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -92,7 +92,7 @@ Set of fields that allow you to generate a collection with random lengths. By de
     :language: python
 
 Allow None Optionals
-----------------------------
+--------------------
 
 Allow `None` to be generated as a value for types marked as optional. When set to `True`, the outputted value will be randomly chosen between `None` and other allowed types. By default, this is set to `True`.
 
@@ -112,4 +112,18 @@ Any other field definition will not be checked.
 
 .. literalinclude:: /examples/configuration/test_example_8.py
     :caption: Enable Check Factory Fields
+    :language: python
+
+Use Default Values
+------------------
+
+If ``__use_default__`` is set to ``True``, then the default value will be used instead of creating a random value
+for a given field, provided there's a default value for that field.
+
+By default, ``__use_default__`` is set to ``False.`` If you need more fine grained control, you can override the
+:meth:`BaseFactory <polyfactory.factories.base.BaseFactory.should_use_default_value>` classmethod.
+
+
+.. literalinclude:: /examples/configuration/test_example_9.py
+    :caption: Use Default Values
     :language: python

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -636,11 +636,6 @@ class BaseFactory(ABC, Generic[T]):
         if field_build_parameters is None and cls.should_set_none_value(field_meta=field_meta):
             return None
 
-        if cls.should_use_default_value(field_meta):
-            if callable(field_meta.default):
-                return field_meta.default()
-            return field_meta.default
-
         unwrapped_annotation = unwrap_annotation(field_meta.annotation, random=cls.__random__)
 
         if is_literal(annotation=unwrapped_annotation) and (literal_args := get_args(unwrapped_annotation)):
@@ -871,7 +866,7 @@ class BaseFactory(ABC, Generic[T]):
 
         for field_meta in cls.get_model_fields():
             field_build_parameters = cls.extract_field_build_parameters(field_meta=field_meta, build_args=kwargs)
-            if cls.should_set_field_value(field_meta, **kwargs):
+            if cls.should_set_field_value(field_meta, **kwargs) and not cls.should_use_default_value(field_meta):
                 if hasattr(cls, field_meta.name) and not hasattr(BaseFactory, field_meta.name):
                     field_value = getattr(cls, field_meta.name)
                     if isinstance(field_value, Ignore):

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -794,8 +794,8 @@ class BaseFactory(ABC, Generic[T]):
         :notes:
             - This method is distinct to allow overriding.
 
-        :returns: A boolean determining whether the default value should be used for the given
-        field_meta.
+        :returns: A boolean determining whether the default value should be used for the given field_meta.
+
         """
         return cls.__use_defaults__ and field_meta.default is not Null
 

--- a/tests/test_attrs_factory.py
+++ b/tests/test_attrs_factory.py
@@ -191,3 +191,31 @@ def test_with_init_false() -> None:
         __model__ = Foo
 
     assert FooFactory.build()
+
+
+def test_use_default_with_callable_default() -> None:
+    @define
+    class Foo:
+        default_field: int = attrs.field(default=attrs.Factory(lambda: 10, takes_self=False))
+
+    class FooFactory(AttrsFactory[Foo]):
+        __model__ = Foo
+        __use_defaults__ = True
+
+    foo = FooFactory.build()
+
+    assert foo.default_field == 10
+
+
+def test_use_default_with_non_callable_default() -> None:
+    @define
+    class Foo:
+        default_field: int = attrs.field(default=10)
+
+    class FooFactory(AttrsFactory[Foo]):
+        __model__ = Foo
+        __use_defaults__ = True
+
+    foo = FooFactory.build()
+
+    assert foo.default_field == 10

--- a/tests/test_dataclass_factory.py
+++ b/tests/test_dataclass_factory.py
@@ -1,3 +1,4 @@
+import dataclasses
 from dataclasses import dataclass as vanilla_dataclass
 from dataclasses import field
 from types import ModuleType
@@ -205,3 +206,31 @@ def test_dataclass_with_init_false() -> None:
     result = MyFactory.build()
 
     assert result
+
+
+def test_use_default_with_callable_default() -> None:
+    @vanilla_dataclass
+    class Foo:
+        default_field: int = dataclasses.field(default_factory=lambda: 10)
+
+    class FooFactory(DataclassFactory[Foo]):
+        __model__ = Foo
+        __use_defaults__ = True
+
+    foo = FooFactory.build()
+
+    assert foo.default_field == 10
+
+
+def test_use_default_with_non_callable_default() -> None:
+    @vanilla_dataclass
+    class Foo:
+        default_field: int = 10
+
+    class FooFactory(DataclassFactory[Foo]):
+        __model__ = Foo
+        __use_defaults__ = True
+
+    foo = FooFactory.build()
+
+    assert foo.default_field == 10

--- a/tests/test_msgspec_factory.py
+++ b/tests/test_msgspec_factory.py
@@ -249,3 +249,29 @@ def test_mapping_with_constrained_item_types() -> None:
     validated_foo = msgspec.convert(structs.asdict(foo), Foo)
 
     assert validated_foo == foo
+
+
+def test_use_default_with_callable_default() -> None:
+    class Foo(Struct):
+        default_field: int = msgspec.field(default_factory=lambda: 10)
+
+    class FooFactory(MsgspecFactory[Foo]):
+        __model__ = Foo
+        __use_defaults__ = True
+
+    foo = FooFactory.build()
+
+    assert foo.default_field == 10
+
+
+def test_use_default_with_non_callable_default() -> None:
+    class Foo(Struct):
+        default_field: int = 10
+
+    class FooFactory(MsgspecFactory[Foo]):
+        __model__ = Foo
+        __use_defaults__ = True
+
+    foo = FooFactory.build()
+
+    assert foo.default_field == 10

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -107,3 +107,29 @@ def test_mapping_with_annotated_item_types() -> None:
         __model__ = Foo
 
     assert FooFactory.build()
+
+
+def test_use_default_with_callable_default() -> None:
+    class Foo(BaseModel):
+        default_field: int = Field(default_factory=lambda: 10)
+
+    class FooFactory(ModelFactory[Foo]):
+        __model__ = Foo
+        __use_defaults__ = True
+
+    foo = FooFactory.build()
+
+    assert foo.default_field == 10
+
+
+def test_use_default_with_non_callable_default() -> None:
+    class Foo(BaseModel):
+        default_field: int = Field(default=10)
+
+    class FooFactory(ModelFactory[Foo]):
+        __model__ = Foo
+        __use_defaults__ = True
+
+    foo = FooFactory.build()
+
+    assert foo.default_field == 10


### PR DESCRIPTION
### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- This PR allows users to configure whether to use the default value for a field or not based on the `__use_defaults__` field on the class.
- Users can also have more fine-grained (i.e. per field) control by overriding `BaseFactory.should_use_default_value` classmethod.

### Close Issue(s)

- Closes #466.
