### PR TITLE
fix: constrained unions

### DIFF
--- a/polyfactory/constants.py
+++ b/polyfactory/constants.py
@@ -44,7 +44,7 @@ INSTANTIABLE_TYPE_MAPPING = {
 }
 
 
-if PY_38:
+if not PY_38:
     TYPE_MAPPING = INSTANTIABLE_TYPE_MAPPING
 else:
     # For 3.8, we have to keep the types from typing since dict[str] syntax is not supported in 3.8.

--- a/polyfactory/constants.py
+++ b/polyfactory/constants.py
@@ -22,25 +22,30 @@ try:
 except ImportError:
     UnionType = Union  # type: ignore[misc,assignment]
 
-if sys.version_info >= (3, 9):
-    # Mapping of type annotations into concrete types. This is used to normalize python <= 3.9 annotations.
-    TYPE_MAPPING = {
-        DefaultDict: defaultdict,
-        Deque: deque,
-        Dict: dict,
-        FrozenSet: frozenset,
-        Iterable: list,
-        List: list,
-        Mapping: dict,
-        Sequence: list,
-        Set: set,
-        Tuple: tuple,
-        abc.Iterable: list,
-        abc.Mapping: dict,
-        abc.Sequence: list,
-        abc.Set: set,
-        UnionType: Union,
-    }
+PY_38 = sys.version_info.major == 3 and sys.version_info.minor == 8  # noqa: PLR2004
+
+# Mapping of type annotations into concrete types. This is used to normalize python <= 3.9 annotations.
+INSTANTIABLE_TYPE_MAPPING = {
+    DefaultDict: defaultdict,
+    Deque: deque,
+    Dict: dict,
+    FrozenSet: frozenset,
+    Iterable: list,
+    List: list,
+    Mapping: dict,
+    Sequence: list,
+    Set: set,
+    Tuple: tuple,
+    abc.Iterable: list,
+    abc.Mapping: dict,
+    abc.Sequence: list,
+    abc.Set: set,
+    UnionType: Union,
+}
+
+
+if PY_38:
+    TYPE_MAPPING = INSTANTIABLE_TYPE_MAPPING
 else:
     # For 3.8, we have to keep the types from typing since dict[str] syntax is not supported in 3.8.
     TYPE_MAPPING = {

--- a/polyfactory/constants.py
+++ b/polyfactory/constants.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from collections import abc, defaultdict, deque
 from random import Random
 from typing import (
@@ -21,25 +22,44 @@ try:
 except ImportError:
     UnionType = Union  # type: ignore[misc,assignment]
 
+if sys.version_info >= (3, 9):
+    # Mapping of type annotations into concrete types. This is used to normalize python <= 3.9 annotations.
+    TYPE_MAPPING = {
+        DefaultDict: defaultdict,
+        Deque: deque,
+        Dict: dict,
+        FrozenSet: frozenset,
+        Iterable: list,
+        List: list,
+        Mapping: dict,
+        Sequence: list,
+        Set: set,
+        Tuple: tuple,
+        abc.Iterable: list,
+        abc.Mapping: dict,
+        abc.Sequence: list,
+        abc.Set: set,
+        UnionType: Union,
+    }
+else:
+    # For 3.8, we have to keep the types from typing since dict[str] syntax is not supported in 3.8.
+    TYPE_MAPPING = {
+        DefaultDict: DefaultDict,
+        Deque: Deque,
+        Dict: Dict,
+        FrozenSet: FrozenSet,
+        Iterable: List,
+        List: List,
+        Mapping: Dict,
+        Sequence: List,
+        Set: Set,
+        Tuple: Tuple,
+        abc.Iterable: List,
+        abc.Mapping: Dict,
+        abc.Sequence: List,
+        abc.Set: Set,
+    }
 
-# Mapping of type annotations into concrete types. This is used to normalize python <= 3.9 annotations.
-TYPE_MAPPING = {
-    DefaultDict: defaultdict,
-    Deque: deque,
-    Dict: dict,
-    FrozenSet: frozenset,
-    Iterable: list,
-    List: list,
-    Mapping: dict,
-    Sequence: list,
-    Set: set,
-    Tuple: tuple,
-    abc.Iterable: list,
-    abc.Mapping: dict,
-    abc.Sequence: list,
-    abc.Set: set,
-    UnionType: Union,
-}
 
 DEFAULT_RANDOM = Random()
 RANDOMIZE_COLLECTION_LENGTH = False

--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -10,11 +10,10 @@ from polyfactory.constants import DEFAULT_RANDOM, TYPE_MAPPING
 from polyfactory.utils.deprecation import check_for_deprecated_parameters
 from polyfactory.utils.helpers import (
     get_annotation_metadata,
-    normalize_annotation,
     unwrap_annotated,
     unwrap_new_type,
 )
-from polyfactory.utils.predicates import is_annotated, is_any_annotated
+from polyfactory.utils.predicates import is_annotated
 from polyfactory.utils.types import NoneType
 
 if TYPE_CHECKING:
@@ -135,14 +134,14 @@ class FieldMeta:
                 ("max_collection_length", max_collection_length),
             ),
         )
-        field_type = normalize_annotation(annotation, random=random)
 
-        if not constraints and is_annotated(annotation):
+        annotated = is_annotated(annotation)
+        if not constraints and annotated:
             metadata = cls.get_constraints_metadata(annotation)
             constraints = cls.parse_constraints(metadata)
 
-        if not is_any_annotated(annotation):
-            annotation = TYPE_MAPPING[field_type] if field_type in TYPE_MAPPING else field_type
+        if annotated:
+            annotation = get_args(annotation)[0]
         elif (origin := get_origin(annotation)) and origin in TYPE_MAPPING:  # pragma: no cover
             container = TYPE_MAPPING[origin]
             annotation = container[get_args(annotation)]  # type: ignore[index]

--- a/polyfactory/value_generators/complex_types.py
+++ b/polyfactory/value_generators/complex_types.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, AbstractSet, Any, Iterable, MutableMapping, Mu
 
 from typing_extensions import is_typeddict
 
+from polyfactory.constants import INSTANTIABLE_TYPE_MAPPING, PY_38
 from polyfactory.field_meta import FieldMeta
 from polyfactory.utils.model_coverage import CoverageContainer
 
@@ -20,6 +21,10 @@ def handle_collection_type(field_meta: FieldMeta, container_type: type, factory:
 
     :returns: A built result.
     """
+
+    if PY_38:
+        container_type = INSTANTIABLE_TYPE_MAPPING[container_type]  # type: ignore[assignment]
+
     container = container_type()
     if not field_meta.children:
         return container

--- a/polyfactory/value_generators/complex_types.py
+++ b/polyfactory/value_generators/complex_types.py
@@ -22,7 +22,7 @@ def handle_collection_type(field_meta: FieldMeta, container_type: type, factory:
     :returns: A built result.
     """
 
-    if PY_38:
+    if PY_38 and container_type in INSTANTIABLE_TYPE_MAPPING:
         container_type = INSTANTIABLE_TYPE_MAPPING[container_type]  # type: ignore[assignment]
 
     container = container_type()

--- a/tests/test_msgspec_factory.py
+++ b/tests/test_msgspec_factory.py
@@ -279,13 +279,14 @@ def test_use_default_with_non_callable_default() -> None:
 
 def test_union_types() -> None:
     class A(Struct):
-        a: Union[List[str], List[int]]
+        a: Union[List[str], int]
         b: Union[str, List[int]]
-        c: List[Union[Tuple[int, int], Tuple[str, int]]]
+        c: List[Union[Tuple[int, int], float]]
 
     AFactory = MsgspecFactory.create_factory(A)
 
-    assert AFactory.build()
+    a = AFactory.build()
+    assert msgspec.convert(structs.asdict(a), A) == a
 
 
 def test_collection_unions_with_models() -> None:
@@ -296,12 +297,13 @@ def test_collection_unions_with_models() -> None:
         a: str
 
     class C(Struct):
-        a: Union[List[A], List[B]]
-        b: List[Union[A, B]]
+        a: Union[List[A], str]
+        b: List[Union[A, int]]
 
     CFactory = MsgspecFactory.create_factory(C)
 
-    assert CFactory.build()
+    c = CFactory.build()
+    assert msgspec.convert(structs.asdict(c), C) == c
 
 
 def test_constrained_union_types() -> None:
@@ -311,7 +313,8 @@ def test_constrained_union_types() -> None:
 
     AFactory = MsgspecFactory.create_factory(A)
 
-    assert AFactory.build()
+    a = AFactory.build()
+    assert msgspec.convert(structs.asdict(a), A) == a
 
 
 @pytest.mark.parametrize("allow_none", (True, False))
@@ -326,4 +329,5 @@ def test_optional_type(allow_none: bool) -> None:
 
         __allow_none_optionals__ = allow_none
 
-    assert AFactory.build()
+    a = AFactory.build()
+    assert msgspec.convert(structs.asdict(a), A) == a

--- a/tests/test_msgspec_factory.py
+++ b/tests/test_msgspec_factory.py
@@ -313,7 +313,7 @@ def test_constrained_union_types() -> None:
         b: Union[List[Annotated[str, Meta(min_length=20)]], int]
         c: Optional[Annotated[int, Meta(ge=1000)]]
         d: Union[Annotated[List[int], Meta(min_length=100)], Annotated[str, Meta(min_length=100)]]
-        e: Optional[Union[Annotated[list[int], Meta(min_length=100)], Annotated[str, Meta(min_length=100)]]]
+        e: Optional[Union[Annotated[List[int], Meta(min_length=100)], Annotated[str, Meta(min_length=100)]]]
         f: Optional[Union[Annotated[List[int], Meta(min_length=100)], str]]
 
     AFactory = MsgspecFactory.create_factory(A, __allow_none_optionals__=False)

--- a/tests/test_msgspec_factory.py
+++ b/tests/test_msgspec_factory.py
@@ -310,8 +310,12 @@ def test_constrained_union_types() -> None:
     class A(Struct):
         a: Union[Annotated[List[str], Meta(min_length=10)], Annotated[int, Meta(ge=1000)]]
         b: Union[List[Annotated[str, Meta(min_length=20)]], int]
+        c: Optional[Annotated[int, Meta(ge=1000)]]
+        d: Union[Annotated[List[int], Meta(min_length=100)], Annotated[str, Meta(min_length=100)]]
+        e: Optional[Union[Annotated[list[int], Meta(min_length=100)], Annotated[str, Meta(min_length=100)]]]
+        f: Optional[Union[Annotated[List[int], Meta(min_length=100)], str]]
 
-    AFactory = MsgspecFactory.create_factory(A)
+    AFactory = MsgspecFactory.create_factory(A, __allow_none_optionals__=False)
 
     a = AFactory.build()
     assert msgspec.convert(structs.asdict(a), A) == a

--- a/tests/test_msgspec_factory.py
+++ b/tests/test_msgspec_factory.py
@@ -106,6 +106,7 @@ def test_with_new_type() -> None:
     class User(Struct):
         name: UnixName
         groups: List[UnixName]
+        constrained_name: Annotated[UnixName, Meta(min_length=20)]
 
     class UserFactory(MsgspecFactory[User]):
         __model__ = User
@@ -332,6 +333,20 @@ def test_optional_type(allow_none: bool) -> None:
         __model__ = A
 
         __allow_none_optionals__ = allow_none
+
+    a = AFactory.build()
+    assert msgspec.convert(structs.asdict(a), A) == a
+
+
+def test_annotated_children() -> None:
+    class A(Struct):
+        a: Dict[int, Annotated[str, Meta(min_length=20)]]
+        b: List[Annotated[int, Meta(gt=1000)]]
+        c: Annotated[List[Annotated[int, Meta(gt=1000)]], Meta(min_length=50)]
+        d: Dict[int, Annotated[List[Annotated[str, Meta(min_length=1)]], Meta(min_length=1)]]
+
+    class AFactory(MsgspecFactory[A]):
+        __model__ = A
 
     a = AFactory.build()
     assert msgspec.convert(structs.asdict(a), A) == a

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -432,8 +432,12 @@ def test_constrained_union_types() -> None:
     class A(BaseModel):
         a: Union[Annotated[List[str], MinLen(100)], Annotated[int, Ge(1000)]]
         b: Union[List[Annotated[str, MinLen(100)]], int]
+        c: Union[Annotated[List[int], MinLen(100)], None]
+        d: Union[Annotated[List[int], MinLen(100)], Annotated[List[str], MinLen(100)]]
+        e: Optional[Union[Annotated[list[int], MinLen(10)], Annotated[list[str], MinLen(10)]]]
+        f: Optional[Union[Annotated[List[int], MinLen(10)], List[str]]]
 
-    AFactory = ModelFactory.create_factory(A)
+    AFactory = ModelFactory.create_factory(A, __allow_none_optionals__=False)
 
     assert AFactory.build()
 

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -17,7 +17,7 @@ from typing import Callable, Dict, List, Literal, Optional, Set, Tuple, Union
 from uuid import UUID
 
 import pytest
-from annotated_types import Ge, Le, LowerCase, MinLen, UpperCase
+from annotated_types import Ge, Gt, Le, LowerCase, MinLen, UpperCase
 from typing_extensions import Annotated, TypeAlias
 
 import pydantic
@@ -808,3 +808,15 @@ def test_complex_constrained_attribute_parsing_pydantic_v2() -> None:
     assert isinstance(next(iter(result.conlist_with_complex_type[0].values())), tuple)
     assert len(next(iter(result.conlist_with_complex_type[0].values()))) == 3
     assert all(isinstance(v, Person) for v in next(iter(result.conlist_with_complex_type[0].values())))
+
+
+def test_annotated_children() -> None:
+    class A(BaseModel):
+        a: Dict[int, Annotated[str, MinLen(min_length=20)]]
+        b: List[Annotated[int, Gt(gt=1000)]]
+        c: Annotated[List[Annotated[int, Gt(gt=1000)]], MinLen(min_length=50)]
+        d: Dict[int, Annotated[list[Annotated[str, MinLen(1)]], MinLen(1)]]
+
+    AFactory = ModelFactory.create_factory(A)
+
+    assert AFactory.build()

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -434,7 +434,7 @@ def test_constrained_union_types() -> None:
         b: Union[List[Annotated[str, MinLen(100)]], int]
         c: Union[Annotated[List[int], MinLen(100)], None]
         d: Union[Annotated[List[int], MinLen(100)], Annotated[List[str], MinLen(100)]]
-        e: Optional[Union[Annotated[list[int], MinLen(10)], Annotated[list[str], MinLen(10)]]]
+        e: Optional[Union[Annotated[List[int], MinLen(10)], Annotated[list[str], MinLen(10)]]]
         f: Optional[Union[Annotated[List[int], MinLen(10)], List[str]]]
 
     AFactory = ModelFactory.create_factory(A, __allow_none_optionals__=False)
@@ -815,7 +815,7 @@ def test_annotated_children() -> None:
         a: Dict[int, Annotated[str, MinLen(min_length=20)]]
         b: List[Annotated[int, Gt(gt=1000)]]
         c: Annotated[List[Annotated[int, Gt(gt=1000)]], MinLen(min_length=50)]
-        d: Dict[int, Annotated[list[Annotated[str, MinLen(1)]], MinLen(1)]]
+        d: Dict[int, Annotated[List[Annotated[str, MinLen(1)]], MinLen(1)]]
 
     AFactory = ModelFactory.create_factory(A)
 

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -434,7 +434,7 @@ def test_constrained_union_types() -> None:
         b: Union[List[Annotated[str, MinLen(100)]], int]
         c: Union[Annotated[List[int], MinLen(100)], None]
         d: Union[Annotated[List[int], MinLen(100)], Annotated[List[str], MinLen(100)]]
-        e: Optional[Union[Annotated[List[int], MinLen(10)], Annotated[list[str], MinLen(10)]]]
+        e: Optional[Union[Annotated[List[int], MinLen(10)], Annotated[List[str], MinLen(10)]]]
         f: Optional[Union[Annotated[List[int], MinLen(10)], List[str]]]
 
     AFactory = ModelFactory.create_factory(A, __allow_none_optionals__=False)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- Fix the parsing of the constraints from union types for Pydantic v2 models
    - Before there used to be special handling of optional types, but that's not needed since optional types are also unions and so optional types should also be handled the same way as union types where we just ignore `NoneType`. This makes the change the same as that of `FieldMeta.from_type` (as changed in #491).
- Fix the way the annotated types are handled when calling `FieldMeta.from-type` by using the actual type that is annotated rather than `Annotated[type, ...]`
    - Due to the change in `FieldMeta.type_args` in #491, `Annotated[List[str], MinLen(10)]` now returns `List[str]` whereas before it would have returned `str` as the child. This results in the children for the `FieldMeta` corresponding to the annotation `Annotated[List[str], MinLen(10)]` to be `List[str]` instead of `str`. Unwrapping the annotation to get the actual underlying type fixes this problem since now `FieldMeta.type_args` will return `str` in this case instead of `List[str]`.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Fixes #493
