### PR TITLE
fix: prefer `sqlalchemy.type.impl` if it exists

### DIFF
--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -126,7 +126,11 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
         elif issubclass(column_type, types.ARRAY):
             annotation = List[column.type.item_type.python_type]  # type: ignore[assignment,name-defined]
         else:
-            annotation = column.type.impl.python_type if hasattr(column.type, "impl") else column.type.python_type  # pyright: ignore[reportGeneralTypeIssues]
+            annotation = (
+                column.type.impl.python_type  # pyright: ignore[reportGeneralTypeIssues]
+                if hasattr(column.type, "impl")
+                else column.type.python_type
+            )
 
         if column.nullable:
             annotation = Union[annotation, None]  # type: ignore[assignment]

--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -126,7 +126,7 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
         elif issubclass(column_type, types.ARRAY):
             annotation = List[column.type.item_type.python_type]  # type: ignore[assignment,name-defined]
         else:
-            annotation = column.type.python_type
+            annotation = column.type.impl.python_type if hasattr(column.type, "impl") else column.type.python_type
 
         if column.nullable:
             annotation = Union[annotation, None]  # type: ignore[assignment]

--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -126,7 +126,7 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
         elif issubclass(column_type, types.ARRAY):
             annotation = List[column.type.item_type.python_type]  # type: ignore[assignment,name-defined]
         else:
-            annotation = column.type.impl.python_type if hasattr(column.type, "impl") else column.type.python_type
+            annotation = column.type.impl.python_type if hasattr(column.type, "impl") else column.type.python_type  # pyright: ignore[reportGeneralTypeIssues]
 
         if column.nullable:
             annotation = Union[annotation, None]  # type: ignore[assignment]


### PR DESCRIPTION
This PR checks for the `impl` property before default to `type.python_type`.

This is the documented way to use the [`sqlalchemy.types.TypeDecorator`](https://docs.sqlalchemy.org/en/20/core/custom_types.html#augmenting-existing-types)