### PR TITLE
fix: respect both mulitple_of and minimum/maximum constraints

### DIFF
--- a/tests/test_number_generation.py
+++ b/tests/test_number_generation.py
@@ -1,3 +1,4 @@
+from decimal import Decimal, localcontext
 from random import Random
 
 import pytest
@@ -6,24 +7,61 @@ from polyfactory.value_generators.constrained_numbers import (
     generate_constrained_number,
     passes_pydantic_multiple_validator,
 )
-from polyfactory.value_generators.primitives import create_random_float
+from polyfactory.value_generators.primitives import create_random_decimal, create_random_float
 
 
 @pytest.mark.parametrize(
     ("maximum", "minimum", "multiple_of"),
-    ((100, 2, 8), (-100, -187, -10), (7.55, 0.13, 0.0123)),
+    (
+        (100, 2, 8),
+        (-100, -187, -10),
+        (7.55, 0.13, 0.0123),
+        (None, 10, 3),
+        (None, -10, 3),
+        (13, 2, None),
+        (50, None, 7),
+        (-50, None, 7),
+        (None, None, 4),
+        (900, None, 1000),
+    ),
 )
-def test_generate_constrained_number(maximum: float, minimum: float, multiple_of: float) -> None:
-    assert passes_pydantic_multiple_validator(
+def test_generate_constrained_number(maximum: float | None, minimum: float | None, multiple_of: float | None) -> None:
+    value = generate_constrained_number(
+        random=Random(),
+        minimum=minimum,
+        maximum=maximum,
         multiple_of=multiple_of,
-        value=generate_constrained_number(
+        method=create_random_float,
+    )
+    if maximum is not None:
+        assert value <= maximum
+    if minimum is not None:
+        assert value >= minimum
+    if multiple_of is not None:
+        assert passes_pydantic_multiple_validator(multiple_of=multiple_of, value=value)
+
+
+def test_generate_constrained_number_with_overprecise_decimals() -> None:
+    minimum = Decimal("1.0005")
+    maximum = Decimal("2")
+    multiple_of = Decimal("1.0005")
+
+    with localcontext() as ctx:
+        ctx.prec = 3
+
+        value = generate_constrained_number(
             random=Random(),
             minimum=minimum,
             maximum=maximum,
             multiple_of=multiple_of,
-            method=create_random_float,
-        ),
-    )
+            method=create_random_decimal,
+        )
+        if maximum is not None:
+            assert value <= ctx.create_decimal(maximum)
+        if minimum is not None:
+            assert value >= ctx.create_decimal(minimum)
+        if multiple_of is not None:
+            assert passes_pydantic_multiple_validator(multiple_of=ctx.create_decimal(multiple_of), value=value)
 
 
 def test_passes_pydantic_multiple_validator_handles_zero_multiplier() -> None:


### PR DESCRIPTION
Note that this does not pass all tests yet, and I need some guidance on what to do on the failures, since I think they correspond to very unrealistic inputs, but it is extremely challenging to communicate to Hypothesis to not generate those kinds of inputs. See the **Open Questions** section below. Apologies in advance for the huge wall of text, and no offense taken if you don't read all of it and can just short circuit it with a simple "Don't do X".

I am ignoring the code complexity lint error for now, since I think the function I wrote may change significantly, so I do not want to refactor it into smaller pieces until we decide on the right approach.

<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

Previously, `generate_constrained_number()` would potentially generate invalid numbers when `mulitple_of` is not None and exactly one of either `minimum` or `maximum` is not None, since it would just return `mulitple_of` without respecting the upper or lower bound.

This significantly changes the implementation of
`generate_constrained_number()` in an attempt to handle this case. We now first check for the presence of `mulitple_of`, and if it is None, then we return early by delegating to the `method` parameter.

Otherwise, we first generate a random number with `method`, and then we attempt to find the nearest number that is a proper multiple of `mulitple_of`. Most of the newly added complexity of the function is meant to handle floating-point or Decimal precision issues, and in worst-case scenarios, it may still not be capable of finding a legal value.

#### Open Questions

Although the making the change described above was not too difficult, the Hypothesis-based tests seem to be finding an almost endless number of failing test cases, with nearly all of them related to precision in floating-point and Decimal numbers. I've included many of these fixes in the code changes, which I have heavily commented, but I'm debating rolling back some of these because I fear that handling every case will cause too much complexity in handling unrealistic edge cases.

Before I go into technical detail about the kinds of issues I am hitting, I'd first like to ask some high-level questions about the policy or intent of the code in terms of accuracy or error handling. There are cases when, due to precision and rounding errors, it is impossible to return a value that satisfies all the constraints, especially due to `method` being an opaque function passed into this function for generating random numbers, so we cannot mathematically reason about its probability distribution function.

- Is the function allowed to infinite loop? We are reliant on `method` to generate random numbers, but it's possible that `method` is overly constrained and will never generate valid numbers
- Does the function need to be deterministic? In my implementation, I try to generate a number up to 10 times before giving up, but Hypothesis can very frequently catch this and find inputs in which sometimes it succeeds and other times it runs out of attempts, labeling the function "flaky"
- Must the function actually respect `method`? For example, if the implementation of `method` does not actually generate random numbers for the whole range specified by `minimum` and `maximum`, it's possible that there are no multiples of `multiple_of` that lie within the range of values that `method` is willing to sample from, but there is no way for us to analytically determine this, since the implementation is opaque
- Can we change the definition of `create_random_float()`? This is the `method` passed in to `generate_constrained_number()` for floats, but the hardcoded constants of 100.0 in certain scenarios causes issues when minimum or maximum take on extreme values

---

With that out of the way, here are some of the technical issues that I have encountered.

First, Decimal numbers are specifically difficult to deal with, since the [`passes_pydantic_multiple_validator()`](https://github.com/litestar-org/polyfactory/blob/c4e3d919368d158f839a6ea6278a28007fb7f5dc/polyfactory/value_generators/constrained_numbers.py#L102-L114) function unconditionally converts the input numbers to floats. I have encountered errors in Hypothesis where I generate a Decimal value that is a perfect multiple of `multiple_of` (i.e. exactly 0 rounding error), but when they get converted to floats for this check, they are not within the 1e-8 threshold that `almost_equals_floats` requires. Arguably, the bug is in Pydantic, since [Pydantic v1](https://github.com/pydantic/pydantic/blob/511d862ec9895de6999d260ac4c790d0b233e316/pydantic/v1/validators.py#L178-L184) did the forced float conversion for Decimals, potentially rejecting inputs that genuinely were a perfect multiple of `multiple_of`.

This can be accounted for by putting extra constraints on Hypothesis's value generators, but the actual constraints are more complex than they initially appear. Due to how precision and errors accumulate with floating-point and Decimal math operators, both the `float(value) / float(multiple_of)` _and_ the `% 1` can cause precision loss. For the former, we have to bound the ratio of the exponents of the two terms, but for the latter, we actually have to bound the ratio of the exponents of the LHS and the RHS of the `%` operator, where the `1` has an exponent of `0`.

I have the above issue fixed in the code, but it's quite frustrating because the base algorithm will find a perfect multiple in Decimal only for it to fail the `passes_pydantic_multiple_validator()`, due to losing precision when converting to floats.

For the case of floating-point numbers as input, we fortunately do not have the above issue, but we hit many more issues due to the limitations of floating-point precision in the first place. What's really challenging is the opaque `method()` random number generator, since at least in some of the test cases that I'm failing, the RNG implementation is not very random, and will sometimes be impossible to find a valid number.

In the test cases that I've debugged, we appear to be using [`create_random_float()`](https://github.com/litestar-org/polyfactory/blob/c4e3d919368d158f839a6ea6278a28007fb7f5dc/polyfactory/value_generators/primitives.py#L11-L28), and in the case where a maximum, but not a minimum, is provided, it sets the minimum bound to `maximum - 100.0`. When maximum is something extremely large like 1e303, it causes the minimum to be set to the literally the same value as the maximum, since `1e303 - 100.0 == 1e303` due to floating-point precision rounding.

The reason this is an issue is because `generate_constrained_number()` does not know anything about the `method` RNG function that is being passed into it. One would naively think that if you call `generate_constrained_number()` with multiple_of and maximum set to some value, and minimum set to None, that it should always successfully find some value, since without a minimum bound, there are almost infinitely possible multiples to choose. The issue is that `method` might not actually be sampling from that entire space, so just trying again with a new random number obtained from `method()` might never succeed, but there is no way for `generate_constrained_number()` to know anything about the internals of `method()` other than attempting to call it.

---

I feel like I've been playing a cat-and-mouse game with Hypothesis, where every time I offer a workaround to one problem, it comes up with another. It's led me to think that this entire approach for generating random numbers with `multiple_of` constraints is flawed.

When you have a multiple-of constraint for a domain of floating-point or Decimal numbers, you are essentially restricting the domain to something isomorphic to a subset of the integers. Not to go too deep into the math, but the Reals are an uncountably large set, while the Integers are countable (almost by definition). However, when you impose a multiple-of constraint on the Reals, you are imposing a one-to-one correspondence with the Integers, since the only allowed numbers are ones that are an integer multiple of some selected `multiple_of` value.

Sampling from a probability distribution defined on the Reals doesn't really make sense for selecting values that are isomorphic to the Integers. Although the approach of finding the nearest integer multiple would work with infinitely precise Real numbers, this approach doesn't always work with finite-precision computer types like floats and Decimals. In practice, this probably isn't an issue, because I can't imagine a use case for setting a multiple-of constraint for floats or decimals that involve huge differences in orders of magnitude between the `maximum` and `multiple_of` parameters, but Hypothesis seems to be hellbent on finding extreme inputs that suffer from these precision issues.

I think what probably makes a lot more sense is when a `multiple_of` is specified, to instead switch to a different strategy of _sampling_ from the Integers, using the sampled number as a multiplier against the `multiple_of` to obtain the final value. It's also not too difficult to translate the bounds constraints to the "multiplier sample space" by just dividing by the `multiple_of`.

The only issue with this approach is that `method`, the random distribution, is provided by the caller, so `generate_constrained_number()` cannot just switch to a different random distribution on its own (unless we are OK with defining `method` as merely a "suggestion" but not a "requirement").

---

Sorry again for the rambling. It's been difficult for me to organize my thoughts because the core of the solution is simple, but the edge cases seem to be endless, and they all seem to involve unfortunate defaults that are outside the scope of `generate_constrained_number()`, but that Hypothesis seems to have no trouble stirring up.

I'm happy to significantly rework this PR, including rewriting it from scratch, if you're able to provide guidance on what we should do here.

### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- #503