### PR TITLE
fix: use provider map for generating value for 'Any'

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -491,7 +491,7 @@ class BaseFactory(ABC, Generic[T]):
             return lambda *args: None
 
         return {
-            Any: lambda: None,
+            Any: lambda: create_random_string(cls.__random__, min_length=1, max_length=10),
             # primitives
             object: object,
             float: cls.__faker__.pyfloat,

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -747,7 +747,7 @@ class BaseFactory(ABC, Generic[T]):
 
             return handle_collection_type(field_meta, origin, cls)
 
-        if is_any(unwrapped_annotation) or isinstance(unwrapped_annotation, TypeVar):
+        if isinstance(unwrapped_annotation, TypeVar):
             return create_random_string(cls.__random__, min_length=1, max_length=10)
 
         if provider := cls.get_provider_map().get(unwrapped_annotation):

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -747,11 +747,11 @@ class BaseFactory(ABC, Generic[T]):
 
             return handle_collection_type(field_meta, origin, cls)
 
-        if isinstance(unwrapped_annotation, TypeVar):
-            return create_random_string(cls.__random__, min_length=1, max_length=10)
-
         if provider := cls.get_provider_map().get(unwrapped_annotation):
             return provider()
+
+        if isinstance(unwrapped_annotation, TypeVar):
+            return create_random_string(cls.__random__, min_length=1, max_length=10)
 
         if callable(unwrapped_annotation):
             # if value is a callable we can try to naively call it.

--- a/tests/test_provider_map.py
+++ b/tests/test_provider_map.py
@@ -1,6 +1,8 @@
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Callable
 
 from polyfactory.factories.base import BaseFactory
+from polyfactory.factories.dataclass_factory import DataclassFactory
 
 
 def test_provider_map() -> None:
@@ -10,3 +12,21 @@ def test_provider_map() -> None:
     for type_, handler in provider_map.items():
         value = handler()
         assert isinstance(value, type_)
+
+
+def test_provider_map_with_any() -> None:
+    @dataclass
+    class Foo:
+        foo: Any
+
+    class FooFactory(DataclassFactory[Foo]):
+        @classmethod
+        def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:
+            provider_map = super().get_provider_map()
+            provider_map[Any] = lambda: "any"
+
+            return provider_map
+
+    foo = FooFactory.build()
+
+    assert foo.foo == "any"

--- a/tests/test_provider_map.py
+++ b/tests/test_provider_map.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Generic, TypeVar
 
 from polyfactory.factories.base import BaseFactory
 from polyfactory.factories.dataclass_factory import DataclassFactory
@@ -24,6 +24,26 @@ def test_provider_map_with_any() -> None:
         def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:
             provider_map = super().get_provider_map()
             provider_map[Any] = lambda: "any"
+
+            return provider_map
+
+    foo = FooFactory.build()
+
+    assert foo.foo == "any"
+
+
+def test_provider_map_with_typevar() -> None:
+    T = TypeVar("T")
+
+    @dataclass
+    class Foo(Generic[T]):
+        foo: T
+
+    class FooFactory(DataclassFactory[Foo]):
+        @classmethod
+        def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:
+            provider_map = super().get_provider_map()
+            provider_map[T] = lambda: "any"
 
             return provider_map
 

--- a/tests/test_provider_map.py
+++ b/tests/test_provider_map.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, TypeVar
+from typing import Any, Callable, Dict, Generic, TypeVar
 
 from polyfactory.factories.base import BaseFactory
 from polyfactory.factories.dataclass_factory import DataclassFactory
@@ -21,7 +21,7 @@ def test_provider_map_with_any() -> None:
 
     class FooFactory(DataclassFactory[Foo]):
         @classmethod
-        def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:
+        def get_provider_map(cls) -> Dict[Any, Callable[[], Any]]:
             provider_map = super().get_provider_map()
             provider_map[Any] = lambda: "any"
 
@@ -41,7 +41,7 @@ def test_provider_map_with_typevar() -> None:
 
     class FooFactory(DataclassFactory[Foo]):
         @classmethod
-        def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:
+        def get_provider_map(cls) -> Dict[Any, Callable[[], Any]]:
             provider_map = super().get_provider_map()
             provider_map[T] = lambda: "any"
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
<!--
Please describe your pull request for new release changelog purposes
-->

- We were incorrectly not considering the value provided in the provider map for any field typed as `Any.` This ensures that we consider the value given in the provider map allowing users to override the generated value.
- This also fixes the same issue that may arise if the user wishes to override the value generated for `TypeVar`.


### Close Issue(s)
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234
-->

- Fixes #521.
