### PR TITLE
feat(sqla_factory): refresh object in async_session after commit to db

### DIFF
--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -101,7 +101,7 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
             postgresql.HSTORE: lambda: cls.__faker__.pydict(),
             # `types.JSON` is compatible for sqlachemy extend dialects. Such as `pg.JSON` and `JSONB`
             # accept `str,int,float` as basic types in case `sqlalchemy/sql/sqltypes.json.json_serializer` raise error
-            types.JSON: lambda: cls.__faker__.pydict(value_types=[int, str, float]),
+            types.JSON: lambda: cls.__faker__.pydict(),
         }
 
     @classmethod

--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -100,7 +100,6 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
             postgresql.TSTZRANGE: lambda: (cls.__faker__.past_datetime(), datetime.now()),  # noqa: DTZ005
             postgresql.HSTORE: lambda: cls.__faker__.pydict(),
             # `types.JSON` is compatible for sqlachemy extend dialects. Such as `pg.JSON` and `JSONB`
-            # accept `str,int,float` as basic types in case `sqlalchemy/sql/sqltypes.json.json_serializer` raise error
             types.JSON: lambda: cls.__faker__.pydict(),
         }
 

--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -50,11 +50,14 @@ class SQLAASyncPersistence(AsyncPersistenceProtocol[T]):
     async def save(self, data: T) -> T:
         self.session.add(data)
         await self.session.commit()
+        await self.session.refresh(data)
         return data
 
     async def save_many(self, data: list[T]) -> list[T]:
         self.session.add_all(data)
         await self.session.commit()
+        for batch_item in data:
+            await self.session.refresh(batch_item)
         return data
 
 

--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -100,7 +100,8 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
             postgresql.TSTZRANGE: lambda: (cls.__faker__.past_datetime(), datetime.now()),  # noqa: DTZ005
             postgresql.HSTORE: lambda: cls.__faker__.pydict(),
             # `types.JSON` is compatible for sqlachemy extend dialects. Such as `pg.JSON` and `JSONB`
-            types.JSON: lambda: cls.__faker__.pydict(),
+            # accept `str,int,float` as basic types in case `sqlalchemy/sql/sqltypes.json.json_serializer` raise error
+            types.JSON: lambda: cls.__faker__.pydict(value_types=[int, str, float]),
         }
 
     @classmethod

--- a/tests/sqlalchemy_factory/test_sqlalchemy_factory_common.py
+++ b/tests/sqlalchemy_factory/test_sqlalchemy_factory_common.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Type, Union
 from uuid import UUID
 
 import pytest
-from sqlalchemy import DECIMAL, Column, DateTime, ForeignKey, Integer, String, create_engine, func, inspect, orm, types
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, create_engine, func, inspect, orm, types
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -319,7 +319,6 @@ async def test_async_persistence(
         __tablename__ = "table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        test_float: Mapped[float] = mapped_column(DECIMAL)
         test_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     await create_tables(async_engine, Base)

--- a/tests/sqlalchemy_factory/test_sqlalchemy_factory_common.py
+++ b/tests/sqlalchemy_factory/test_sqlalchemy_factory_common.py
@@ -9,7 +9,7 @@ from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, create_eng
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapped, Session, mapped_column
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.decl_api import DeclarativeMeta, registry
 
 from polyfactory.exceptions import ConfigurationException
@@ -318,8 +318,8 @@ async def test_async_persistence(
     class AsyncModel(Base):
         __tablename__ = "table"
 
-        id: Mapped[int] = mapped_column(primary_key=True)
-        test_datetime: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+        id: Any = Column(Integer(), primary_key=True)
+        test_datetime: Any = Column(DateTime(timezone=True), server_default=func.now())
 
     await create_tables(async_engine, Base)
 

--- a/tests/sqlalchemy_factory/test_sqlalchemy_factory_common.py
+++ b/tests/sqlalchemy_factory/test_sqlalchemy_factory_common.py
@@ -5,7 +5,20 @@ from typing import Any, Callable, Type, Union
 from uuid import UUID
 
 import pytest
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, create_engine, func, inspect, orm, types
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    create_engine,
+    func,
+    inspect,
+    orm,
+    text,
+    types,
+)
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -15,6 +28,7 @@ from sqlalchemy.orm.decl_api import DeclarativeMeta, registry
 from polyfactory.exceptions import ConfigurationException
 from polyfactory.factories.base import BaseFactory
 from polyfactory.factories.sqlalchemy_factory import SQLAlchemyFactory
+from polyfactory.fields import Ignore
 
 
 @pytest.fixture()
@@ -319,7 +333,6 @@ async def test_async_persistence(
         __tablename__ = "table"
 
         id: Any = Column(Integer(), primary_key=True)
-        test_datetime: Any = Column(DateTime(timezone=True), server_default=func.now())
 
     await create_tables(async_engine, Base)
 
@@ -330,18 +343,61 @@ async def test_async_persistence(
             __model__ = AsyncModel
 
         result = await Factory.create_async()
-        assert result.test_datetime is not None
-        assert isinstance(result.test_datetime, datetime)
         assert inspect(result).persistent  # type: ignore[union-attr]
-        await session.delete(result)
-        await session.commit()
 
         batch_result = await Factory.create_batch_async(size=2)
         assert len(batch_result) == 2
         for batch_item in batch_result:
             assert inspect(batch_item).persistent  # type: ignore[union-attr]
-            assert batch_item.test_datetime is not None
-            assert isinstance(result.test_datetime, datetime)
+
+
+@pytest.mark.parametrize(
+    "session_config",
+    (
+        lambda session: session,
+        lambda session: (lambda: session),
+    ),
+)
+async def test_async_server_default_refresh(
+    async_engine: AsyncEngine,
+    session_config: Callable[[AsyncSession], Any],
+) -> None:
+    _registry = registry()
+
+    class Base(metaclass=DeclarativeMeta):
+        __abstract__ = True
+
+        registry = _registry
+        metadata = _registry.metadata
+
+    class AsyncRefreshModel(Base):
+        __tablename__ = "server_default_test"
+
+        id: Any = Column(Integer(), primary_key=True)
+        test_datetime: Any = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+        test_str: Any = Column(String, nullable=False, server_default=text("test_str"))
+        test_int: Any = Column(Integer, nullable=False, server_default=text("123"))
+        test_bool: Any = Column(Boolean, nullable=False, server_default=text("False"))
+
+    await create_tables(async_engine, Base)
+
+    async with AsyncSession(async_engine) as session:
+
+        class Factory(SQLAlchemyFactory[AsyncRefreshModel]):
+            __async_session__ = session_config(session)
+            __model__ = AsyncRefreshModel
+            test_datetime = Ignore()
+            test_str = Ignore()
+            test_int = Ignore()
+            test_bool = Ignore()
+
+        result = await Factory.create_async()
+        assert inspect(result).persistent  # type: ignore[union-attr]
+        assert result.test_datetime is not None
+        assert isinstance(result.test_datetime, datetime)
+        assert result.test_str == "test_str"
+        assert result.test_int == 123
+        assert result.test_bool is False
 
 
 def test_alias() -> None:


### PR DESCRIPTION
## Description
Use Case: column use `server_default` to generate default value in database side.
If we use asyncsession, and access this attribute from orm object, it will raise `sqlalchemy.exc.MissingGreenlet` error.
There are two ways to solve this issue.
- the first one, refresh it directly after commit (choice this one in this PR, which may add very little latency)
- the second one, add params `refresh` to `create_async()` and `create_batch_async()` and default value is False. it will depends user's input in creation object.

