### PR TITLE
docs(config): link to GitHub repo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,6 +141,7 @@ html_context = {
 html_theme_options = {
     "logo_target": "/",
     "github_repo_name": "polyfactory",
+    "github_url": "https://github.com/litestar-org/polyfactory",
     "navigation_with_keys": True,
     "nav_links": [
         {"title": "Home", "url": "index"},


### PR DESCRIPTION
## Description

- Adds a link to the GitHub repository to the docs page. Follows a similar PR done here https://github.com/litestar-org/advanced-alchemy/pull/191

Current
<img width="155" alt="image" src="https://github.com/litestar-org/polyfactory/assets/45509143/92da7419-bfad-4554-b878-b8d83a0db024">

After
<img width="162" alt="image" src="https://github.com/litestar-org/polyfactory/assets/45509143/1eccaf4e-e179-4872-b65c-28ee7f1e9507">

