### PR TITLE
fix: Adjust min/max items to valid lengths for Set[Enum] fields

### DIFF
--- a/polyfactory/value_generators/constrained_collections.py
+++ b/polyfactory/value_generators/constrained_collections.py
@@ -47,7 +47,8 @@ def handle_constrained_collection(
     if collection_type in (frozenset, set) or unique_items:
         max_field_values = max_items
         if hasattr(field_meta.annotation, "__origin__") and field_meta.annotation.__origin__ is Literal:
-            max_field_values = len(field_meta.children)
+            if field_meta.children is not None:
+                max_field_values = len(field_meta.children)
         elif isinstance(field_meta.annotation, EnumMeta):
             max_field_values = len(field_meta.annotation)
         min_items = min(min_items, max_field_values)

--- a/polyfactory/value_generators/constrained_collections.py
+++ b/polyfactory/value_generators/constrained_collections.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import EnumMeta
 from typing import TYPE_CHECKING, Any, Callable, List, Mapping, TypeVar, cast
 
 from polyfactory.exceptions import ParameterException
@@ -38,6 +39,11 @@ def handle_constrained_collection(
     """
     min_items = abs(min_items if min_items is not None else (max_items or 0))
     max_items = abs(max_items if max_items is not None else min_items + 1)
+
+    if isinstance(field_meta.annotation, EnumMeta):
+        max_items = len(field_meta.annotation)
+        if min_items > max_items:
+            min_items = max_items
 
     if max_items < min_items:
         msg = "max_items must be larger or equal to min_items"

--- a/tests/test_collection_length.py
+++ b/tests/test_collection_length.py
@@ -156,8 +156,7 @@ def test_collection_length_with_literal(type_: type, min_items: int, max_inc: in
 
     result = MyFactory.build()
     assert len(result.animal_collection) >= min(min_items, len(get_args(literal_type)))
-    if type_ is not List:
-        assert len(result.animal_collection) <= max_items
+    assert len(result.animal_collection) <= max_items
 
 
 @pytest.mark.parametrize("type_", (List, FrozenSet, Set))
@@ -182,5 +181,4 @@ def test_collection_length_with_enum(type_: type, min_items: int, max_inc: int) 
 
     result = MyFactory.build()
     assert len(result.animal_collection) >= min(min_items, len(Animal))
-    if type_ is not List:
-        assert len(result.animal_collection) <= max_items
+    assert len(result.animal_collection) <= max_items

--- a/tests/test_complex_types.py
+++ b/tests/test_complex_types.py
@@ -155,6 +155,25 @@ def test_complex_typing_with_enum() -> None:
     assert result.animal_list
 
 
+def test_complex_typing_with_enum_set() -> None:
+    class Animal(str, Enum):
+        DOG = "Dog"
+        CAT = "Cat"
+        MONKEY = "Monkey"
+
+    class MyModel(BaseModel):
+        animal_list: Set[Animal]
+
+    class MyFactory(ModelFactory):
+        __model__ = MyModel
+        __randomize_collection_length__ = True
+        __min_collection_length__ = len(Animal) + 1
+        __min_collection_length__ = len(Animal) + 2
+
+    result = MyFactory.build()
+    assert len(result.animal_list) == len(Animal)
+
+
 def test_union_literal() -> None:
     class MyModel(BaseModel):
         x: Union[int, Literal["a", "b", "c"]]

--- a/tests/test_complex_types.py
+++ b/tests/test_complex_types.py
@@ -155,25 +155,6 @@ def test_complex_typing_with_enum() -> None:
     assert result.animal_list
 
 
-def test_complex_typing_with_enum_set() -> None:
-    class Animal(str, Enum):
-        DOG = "Dog"
-        CAT = "Cat"
-        MONKEY = "Monkey"
-
-    class MyModel(BaseModel):
-        animal_list: Set[Animal]
-
-    class MyFactory(ModelFactory):
-        __model__ = MyModel
-        __randomize_collection_length__ = True
-        __min_collection_length__ = len(Animal) + 1
-        __min_collection_length__ = len(Animal) + 2
-
-    result = MyFactory.build()
-    assert len(result.animal_list) == len(Animal)
-
-
 def test_union_literal() -> None:
     class MyModel(BaseModel):
         x: Union[int, Literal["a", "b", "c"]]


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

For `Set[Enum]` fields with a limited maximum length, adjust `min_items` and `max_items` to be within the range of valid lengths.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Fixes #565
