### PR TITLE
fix: constrained 0 length lists

### DIFF
--- a/polyfactory/value_generators/constrained_collections.py
+++ b/polyfactory/value_generators/constrained_collections.py
@@ -46,7 +46,7 @@ def handle_constrained_collection(
     collection: set[T] | list[T] = set() if (collection_type in (frozenset, set) or unique_items) else []
 
     try:
-        length = factory.__random__.randint(min_items, max_items) or 1
+        length = factory.__random__.randint(min_items, max_items)
         while (i := len(collection)) < length:
             if field_build_parameters and len(field_build_parameters) > i:
                 build_params = field_build_parameters[i]

--- a/tests/constraints/test_frozen_set_constraints.py
+++ b/tests/constraints/test_frozen_set_constraints.py
@@ -83,4 +83,4 @@ def test_handle_constrained_set_with_different_types(t_type: Any) -> None:
             field_meta=FieldMeta(name="test", annotation=frozenset, random=Random()),
             item_type=t_type,
         )
-        assert len(result) > 0
+        assert len(result) >= 0

--- a/tests/constraints/test_list_constraints.py
+++ b/tests/constraints/test_list_constraints.py
@@ -89,7 +89,7 @@ def test_handle_constrained_list_with_different_types(t_type: Any) -> None:
         field_meta=field_meta.children[0],  # type: ignore[index]
         item_type=t_type,
     )
-    assert len(result) > 0
+    assert len(result) >= 0
 
 
 def test_handle_unique_items() -> None:

--- a/tests/constraints/test_set_constraints.py
+++ b/tests/constraints/test_set_constraints.py
@@ -83,4 +83,4 @@ def test_handle_constrained_set_with_different_types(t_type: Any) -> None:
             field_meta=FieldMeta(name="test", annotation=set, random=Random()),
             item_type=t_type,
         )
-        assert len(result) > 0
+        assert len(result) >= 0


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- remove default 1 for length

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes #566 
