### PR TITLE
fix: tuple randomized length

### DIFF
--- a/polyfactory/collection_extender.py
+++ b/polyfactory/collection_extender.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 from abc import ABC, abstractmethod
 from collections import deque
 from typing import Any
@@ -54,36 +53,29 @@ class ListLikeExtender(CollectionExtender):
     __types__ = (list, deque)
 
     @staticmethod
-    def _extend_type_args(type_args: tuple[Any, ...], number_of_args: int) -> tuple[Any, ...]:
-        if not type_args:
-            return type_args
-        return tuple(random.choice(type_args) for _ in range(number_of_args))
+    def _extend_type_args(type_args: tuple[Any, ...], _: int) -> tuple[Any, ...]:
+        return type_args
 
 
 class SetExtender(CollectionExtender):
     __types__ = (set, frozenset)
 
     @staticmethod
-    def _extend_type_args(type_args: tuple[Any, ...], number_of_args: int) -> tuple[Any, ...]:
-        if not type_args:
-            return type_args
-        return tuple(random.choice(type_args) for _ in range(number_of_args))
+    def _extend_type_args(type_args: tuple[Any, ...], _: int) -> tuple[Any, ...]:
+        return type_args
 
 
 class DictExtender(CollectionExtender):
     __types__ = (dict,)
 
     @staticmethod
-    def _extend_type_args(type_args: tuple[Any, ...], number_of_args: int) -> tuple[Any, ...]:
-        return type_args * number_of_args
+    def _extend_type_args(type_args: tuple[Any, ...], _: int) -> tuple[Any, ...]:
+        return type_args
 
 
 class FallbackExtender(CollectionExtender):
     __types__ = ()
 
     @staticmethod
-    def _extend_type_args(
-        type_args: tuple[Any, ...],
-        number_of_args: int,  # noqa: ARG004
-    ) -> tuple[Any, ...]:  # - investigate @guacs
+    def _extend_type_args(type_args: tuple[Any, ...], _: int) -> tuple[Any, ...]:
         return type_args

--- a/polyfactory/collection_extender.py
+++ b/polyfactory/collection_extender.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 from abc import ABC, abstractmethod
 from collections import deque
 from typing import Any
@@ -53,29 +54,36 @@ class ListLikeExtender(CollectionExtender):
     __types__ = (list, deque)
 
     @staticmethod
-    def _extend_type_args(type_args: tuple[Any, ...], _: int) -> tuple[Any, ...]:
-        return type_args
+    def _extend_type_args(type_args: tuple[Any, ...], number_of_args: int) -> tuple[Any, ...]:
+        if not type_args:
+            return type_args
+        return tuple(random.choice(type_args) for _ in range(number_of_args))
 
 
 class SetExtender(CollectionExtender):
     __types__ = (set, frozenset)
 
     @staticmethod
-    def _extend_type_args(type_args: tuple[Any, ...], _: int) -> tuple[Any, ...]:
-        return type_args
+    def _extend_type_args(type_args: tuple[Any, ...], number_of_args: int) -> tuple[Any, ...]:
+        if not type_args:
+            return type_args
+        return tuple(random.choice(type_args) for _ in range(number_of_args))
 
 
 class DictExtender(CollectionExtender):
     __types__ = (dict,)
 
     @staticmethod
-    def _extend_type_args(type_args: tuple[Any, ...], _: int) -> tuple[Any, ...]:
-        return type_args
+    def _extend_type_args(type_args: tuple[Any, ...], number_of_args: int) -> tuple[Any, ...]:
+        return type_args * number_of_args
 
 
 class FallbackExtender(CollectionExtender):
     __types__ = ()
 
     @staticmethod
-    def _extend_type_args(type_args: tuple[Any, ...], _: int) -> tuple[Any, ...]:
+    def _extend_type_args(
+        type_args: tuple[Any, ...],
+        number_of_args: int,  # noqa: ARG004
+    ) -> tuple[Any, ...]:  # - investigate @guacs
         return type_args

--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Literal, Mapping, Pattern, TypedDict, cas
 
 from typing_extensions import get_args, get_origin
 
-from polyfactory.collection_extender import CollectionExtender
 from polyfactory.constants import DEFAULT_RANDOM, TYPE_MAPPING
 from polyfactory.utils.deprecation import check_for_deprecated_parameters
 from polyfactory.utils.helpers import get_annotation_metadata, unwrap_annotated, unwrap_new_type
@@ -152,14 +151,12 @@ class FieldMeta:
         )
 
         if field.type_args and not field.children:
-            number_of_args = 1
-            extended_type_args = CollectionExtender.extend_type_args(field.annotation, field.type_args, number_of_args)
             field.children = [
                 cls.from_type(
                     annotation=unwrap_new_type(arg),
                     random=random,
                 )
-                for arg in extended_type_args
+                for arg in field.type_args
                 if arg is not NoneType
             ]
         return field

--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any, Mapping
+from collections import deque
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 from typing_extensions import TypeAliasType, get_args, get_origin
 
@@ -11,7 +12,6 @@ from polyfactory.utils.types import NoneType
 
 if TYPE_CHECKING:
     from random import Random
-    from typing import Sequence
 
 
 def unwrap_new_type(annotation: Any) -> Any:
@@ -173,7 +173,7 @@ def get_annotation_metadata(annotation: Any) -> Sequence[Any]:
     return get_args(annotation)[1:]
 
 
-def get_collection_type(annotation: Any) -> type[list | tuple | set | frozenset | dict]:
+def get_collection_type(annotation: Any) -> type[list | tuple | set | frozenset | dict | deque]:  # noqa: PLR0911
     """Get the collection type from the annotation.
 
     :param annotation: A type annotation.
@@ -191,6 +191,10 @@ def get_collection_type(annotation: Any) -> type[list | tuple | set | frozenset 
         return set
     if is_safe_subclass(annotation, frozenset):
         return frozenset
+    if is_safe_subclass(annotation, deque):
+        return deque
+    if is_safe_subclass(annotation, Sequence):
+        return list
 
     msg = f"Unknown collection type - {annotation}"
     raise ValueError(msg)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Currently, tuple with fixed length and randomised collection length are not handled correctly. These are treated as arbitary length tuples.
- Remove calls to collection extender so this type is explicitly passed to other places.

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- Fixes #553 
- Fixes #572 
