### PR TITLE
perf: cache provider map

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -53,6 +53,7 @@ from polyfactory.constants import (
 from polyfactory.exceptions import ConfigurationException, MissingBuildKwargException, ParameterException
 from polyfactory.field_meta import Null
 from polyfactory.fields import Fixture, Ignore, PostGenerated, Require, Use
+from polyfactory.utils.cache import copying_lru_cache
 from polyfactory.utils.helpers import (
     flatten_annotation,
     get_collection_type,
@@ -479,6 +480,7 @@ class BaseFactory(ABC, Generic[T]):
         return value is None
 
     @classmethod
+    @copying_lru_cache
     def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:
         """Map types to callables.
 

--- a/polyfactory/factories/msgspec_factory.py
+++ b/polyfactory/factories/msgspec_factory.py
@@ -8,6 +8,7 @@ from typing_extensions import get_type_hints
 from polyfactory.exceptions import MissingDependencyException
 from polyfactory.factories.base import BaseFactory
 from polyfactory.field_meta import FieldMeta, Null
+from polyfactory.utils.cache import copying_lru_cache
 from polyfactory.value_generators.constrained_numbers import handle_constrained_int
 from polyfactory.value_generators.primitives import create_random_bytes
 
@@ -30,6 +31,7 @@ class MsgspecFactory(Generic[T], BaseFactory[T]):
     __is_base_factory__ = True
 
     @classmethod
+    @copying_lru_cache
     def get_provider_map(cls) -> dict[Any, Callable[[], Any]]:
         def get_msgpack_ext() -> msgspec.msgpack.Ext:
             code = handle_constrained_int(cls.__random__, ge=-128, le=127)
@@ -48,6 +50,7 @@ class MsgspecFactory(Generic[T], BaseFactory[T]):
         return isclass(value) and hasattr(value, "__struct_fields__")
 
     @classmethod
+    @copying_lru_cache
     def get_model_fields(cls) -> list[FieldMeta]:
         fields_meta: list[FieldMeta] = []
 

--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -7,6 +7,7 @@ from polyfactory.exceptions import MissingDependencyException
 from polyfactory.factories.base import BaseFactory
 from polyfactory.field_meta import FieldMeta
 from polyfactory.persistence import AsyncPersistenceProtocol, SyncPersistenceProtocol
+from polyfactory.utils.cache import copying_lru_cache
 
 try:
     from sqlalchemy import Column, inspect, types
@@ -157,6 +158,7 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
         return annotation
 
     @classmethod
+    @copying_lru_cache
     def get_model_fields(cls) -> list[FieldMeta]:
         fields_meta: list[FieldMeta] = []
 

--- a/polyfactory/utils/cache.py
+++ b/polyfactory/utils/cache.py
@@ -1,0 +1,19 @@
+import copy
+import functools
+from functools import lru_cache
+from typing import Callable, TypeVar
+
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def copying_lru_cache(fn: Callable[P, R]) -> Callable[P, R]:
+    cached_func = lru_cache(fn)
+
+    @functools.wraps(fn)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        return copy.copy(cached_func(*args, **kwargs))  # type: ignore[arg-type]
+
+    return wrapper

--- a/polyfactory/value_generators/constrained_dates.py
+++ b/polyfactory/value_generators/constrained_dates.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone, tzinfo
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from faker import Faker
@@ -38,4 +38,4 @@ def handle_constrained_date(
     elif lt:
         end_date = lt - timedelta(days=1)
 
-    return faker.date_between(start_date=start_date, end_date=end_date)
+    return cast(date, faker.date_between(start_date=start_date, end_date=end_date))

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Set
+
+from polyfactory.factories.dataclass_factory import DataclassFactory
+from polyfactory.utils.cache import copying_lru_cache
+
+
+def test_copying_lru_cache_copies() -> None:
+    @copying_lru_cache
+    def f() -> Set[str]:
+        return {"foo"}
+
+    result = f()
+    result.add("bar")
+    assert f() == {"foo"}
+
+
+def test_cached_per_class() -> None:
+    class A:
+        @classmethod
+        @copying_lru_cache
+        def name(cls) -> str:
+            return cls.__name__
+
+    class B(A): ...
+
+    assert A.name() == "A"
+    assert B.name() == "B"
+
+
+def test_resetting_random_resets_cache() -> None:
+    @dataclass
+    class A:
+        a: str
+
+    class Factory(DataclassFactory[A]): ...
+
+    Factory.seed_random(1)
+    first_result = Factory.build().a
+    second_result = Factory.build().a
+    assert first_result != second_result
+
+    Factory.seed_random(1)
+    after_reset = Factory.build().a
+    assert first_result == after_reset


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Test locally using
```
➜  polyfactory git:(perf-cache-provider-map) ✗ cat s.py 
# snippet.py
from timeit import timeit

from pydantic import BaseModel

from polyfactory.factories.pydantic_factory import ModelFactory


class Foo(BaseModel):
    id: int
    name: str


class FooFactory(ModelFactory[Foo]):
    pass


def create_pydantic_models() -> None:
    FooFactory.batch(1000)


print(timeit(create_pydantic_models, number=1))
➜  polyfactory git:(perf-cache-provider-map) ✗ git checkout perf-cache-provider-map                                                            <<<
➜  polyfactory git:(perf-cache-provider-map) ✗ pdm run s.py
0.039182167034596205
➜  polyfactory git:(perf-cache-provider-map) ✗                                                                                                 <<<
➜  polyfactory git:(perf-cache-provider-map) ✗ git checkout main                       
Switched to branch 'main'
Your branch is up to date with 'upstream/main'.
➜  polyfactory git:(main) ✗ pdm run s.py                                                                                                       <<<
0.22354750003432855
```
- Resolves https://github.com/litestar-org/polyfactory/discussions/576
- Extra caching functionality is done so copying the result. This preserves existing behaviour where it could be mutated or state is reset for each call
- This might have some side effect in some edge cases where references to `__faker__` instances get changed


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
