### PR TITLE
fix: handle nullable SQLA constraints

### DIFF
--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, List, TypeVar, Union
 
-from sqlalchemy import ARRAY, Numeric, String
 from typing_extensions import Annotated
 
 from polyfactory.exceptions import MissingDependencyException
@@ -13,7 +12,7 @@ from polyfactory.persistence import AsyncPersistenceProtocol, SyncPersistencePro
 from polyfactory.utils.types import Frozendict
 
 try:
-    from sqlalchemy import Column, inspect, types
+    from sqlalchemy import ARRAY, Column, Numeric, String, inspect, types
     from sqlalchemy.dialects import mssql, mysql, postgresql, sqlite
     from sqlalchemy.exc import NoInspectionAvailable
     from sqlalchemy.orm import InstanceState, Mapper

--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from typing import TYPE_CHECKING, Any, Literal, Mapping, Pattern, TypedDict, cast
 
 from typing_extensions import get_args, get_origin
@@ -55,6 +55,29 @@ class Constraints(TypedDict):
     upper_case: NotRequired[bool]
     url: NotRequired[UrlConstraints]
     uuid_version: NotRequired[Literal[1, 3, 4, 5]]
+
+
+@dataclass(frozen=True)
+class MaxLen:
+    """MaxLen() implies maximum inclusive length,
+    e.g. ``len(value) <= max_length``.
+    """
+
+    max_length: int
+
+
+@dataclass(frozen=True)
+class Precision:
+    """Precision() impies Decimal precision"""
+
+    precision: int
+
+
+@dataclass(frozen=True)
+class DecimalPlaces:
+    """DecimalPlaces() impies Decimal places"""
+
+    decimal_places: int
 
 
 class FieldMeta:

--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, is_dataclass
+from dataclasses import asdict, is_dataclass
 from typing import TYPE_CHECKING, Any, Literal, Mapping, Pattern, TypedDict, cast
 
 from typing_extensions import get_args, get_origin
@@ -55,29 +55,6 @@ class Constraints(TypedDict):
     upper_case: NotRequired[bool]
     url: NotRequired[UrlConstraints]
     uuid_version: NotRequired[Literal[1, 3, 4, 5]]
-
-
-@dataclass(frozen=True)
-class MaxLen:
-    """MaxLen() implies maximum inclusive length,
-    e.g. ``len(value) <= max_length``.
-    """
-
-    max_length: int
-
-
-@dataclass(frozen=True)
-class Precision:
-    """Precision() impies Decimal precision"""
-
-    precision: int
-
-
-@dataclass(frozen=True)
-class DecimalPlaces:
-    """DecimalPlaces() impies Decimal places"""
-
-    decimal_places: int
 
 
 class FieldMeta:

--- a/polyfactory/utils/types.py
+++ b/polyfactory/utils/types.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Any, Union
 
 try:
     from types import NoneType, UnionType
@@ -9,4 +9,14 @@ except ImportError:
 
     NoneType = type(None)  # type: ignore[misc]
 
-__all__ = ("NoneType", "UNION_TYPES")
+
+class Frozendict(dict):
+    def __setitem__(self, _: Any, __: Any) -> None:
+        msg = "Unable to set value"
+        raise TypeError(msg)
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        return hash(tuple(self.items()))
+
+
+__all__ = ("NoneType", "UNION_TYPES", "Frozendict")

--- a/polyfactory/utils/types.py
+++ b/polyfactory/utils/types.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, NoReturn, TypeVar, Union
+from typing import TYPE_CHECKING, Any, NoReturn, Union
 
 try:
     from types import NoneType, UnionType
@@ -10,11 +10,7 @@ except ImportError:
     NoneType = type(None)  # type: ignore[misc]
 
 
-K = TypeVar("K")
-V = TypeVar("V")
-
-
-class Frozendict(dict[K, V]):
+class Frozendict(dict):
     def _immutable_error(self, *_: Any, **__: Any) -> NoReturn:
         msg = f"Unable to mutate {type(self).__name__}"
         raise TypeError(msg)

--- a/polyfactory/utils/types.py
+++ b/polyfactory/utils/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import TYPE_CHECKING, Any, NoReturn, TypeVar, Union
 
 try:
     from types import NoneType, UnionType
@@ -10,10 +10,23 @@ except ImportError:
     NoneType = type(None)  # type: ignore[misc]
 
 
-class Frozendict(dict):
-    def __setitem__(self, _: Any, __: Any) -> None:
-        msg = "Unable to set value"
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class Frozendict(dict[K, V]):
+    def _immutable_error(self, *_: Any, **__: Any) -> NoReturn:
+        msg = f"Unable to mutate {type(self).__name__}"
         raise TypeError(msg)
+
+    # Override all mutation methods to prevent changes
+    if not TYPE_CHECKING:
+        __setitem__ = _immutable_error
+        __delitem__ = _immutable_error
+        clear = _immutable_error
+        pop = _immutable_error
+        popitem = _immutable_error
+        update = _immutable_error
 
     def __hash__(self) -> int:  # type: ignore[override]
         return hash(tuple(self.items()))

--- a/tests/sqlalchemy_factory/test_sqlalchemy_factory_common.py
+++ b/tests/sqlalchemy_factory/test_sqlalchemy_factory_common.py
@@ -464,9 +464,14 @@ def test_constrained_types() -> None:
 
         id: Any = Column(Integer(), primary_key=True)
         constrained_string: Any = Column(String(length=1), nullable=False)
+        constrained_nullable_string: Any = Column(String(length=1), nullable=True)
         constrainted_number: Any = Column(
             Numeric(precision=2, scale=1),
             nullable=False,
+        )
+        constrainted_nullable_number: Any = Column(
+            Numeric(precision=2, scale=1),
+            nullable=True,
         )
 
     class ModelFactory(SQLAlchemyFactory[Model]):
@@ -474,6 +479,7 @@ def test_constrained_types() -> None:
 
     instance = ModelFactory.build()
     assert len(instance.constrained_string) <= 1
+    assert instance.constrained_nullable_string is None or len(instance.constrained_nullable_string) <= 1
 
     constrained_number: Decimal = instance.constrainted_number
     assert isinstance(constrained_number, Decimal)

--- a/tests/utils/test_frozendict.py
+++ b/tests/utils/test_frozendict.py
@@ -1,0 +1,13 @@
+import pytest
+
+from polyfactory.utils.types import Frozendict
+
+
+def test_frozendict_immutable() -> None:
+    instance = Frozendict()
+    with pytest.raises(TypeError, match="Unable to set value"):
+        instance["foo"] = "bar"
+
+
+def test_frozendict_hashable() -> None:
+    assert isinstance(hash(Frozendict()), int)

--- a/tests/utils/test_frozendict.py
+++ b/tests/utils/test_frozendict.py
@@ -4,8 +4,8 @@ from polyfactory.utils.types import Frozendict
 
 
 def test_frozendict_immutable() -> None:
-    instance = Frozendict()
-    with pytest.raises(TypeError, match="Unable to set value"):
+    instance = Frozendict({"bar": "foo"})
+    with pytest.raises(TypeError, match="Unable to mutate Frozendict"):
         instance["foo"] = "bar"
 
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Constraints should be hashable to handle downstream usage
- Create `Frozendict` to hold constraints
- Alternative approachs
    - Update to vendor in `annotated-types`-esque classes and change internal to support this and use factories per type to generate. This would be backwards breaking and hard to generate for a user.
    - Pass constraints separately or another way. Not sure if can do this and pass these to `FieldMeta` whilst not breaking exposed interface

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- Fixes #601 