### PR TITLE
docs: fix symbol names in fixture examples

### DIFF
--- a/docs/examples/fixtures/test_example_2.py
+++ b/docs/examples/fixtures/test_example_2.py
@@ -23,8 +23,8 @@ class PersonFactory(DataclassFactory[Person]): ...
 person_factory_fixture = register_fixture(PersonFactory)
 
 
-def test_person_factory(person_factory: PersonFactory) -> None:
-    person_instance = person_factory.build()
+def test_person_factory(person_factory_fixture: PersonFactory) -> None:
+    person_instance = person_factory_fixture.build()
     assert isinstance(person_instance, Person)
 
     # we can still access the factory class itself-

--- a/docs/examples/fixtures/test_example_3.py
+++ b/docs/examples/fixtures/test_example_3.py
@@ -20,7 +20,7 @@ class Person:
 class PersonFactory(DataclassFactory[Person]): ...
 
 
-person_factory_fixture = register_fixture(PersonFactory, name="aliased_person_factory")
+aliased_person_factory = register_fixture(PersonFactory, name="aliased_person_factory")
 
 
 def test_person_factory(aliased_person_factory: PersonFactory) -> None:


### PR DESCRIPTION
## Description

The variable name for the fixture defined in each of these examples did not match fixture names later in the examples.
