### PR TITLE
fix: ensure ABC are not considered a factory type

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import inspect
 from abc import ABC, abstractmethod
 from collections import Counter, abc, deque
 from contextlib import suppress
@@ -404,7 +405,9 @@ class BaseFactory(ABC, Generic[T]):
         :param annotation: A type annotation.
         :returns: Boolean dictating whether the annotation is a factory type
         """
-        return any(factory.is_supported_type(annotation) for factory in BaseFactory._base_factories)
+        return not inspect.isabstract(annotation) and any(
+            factory.is_supported_type(annotation) for factory in BaseFactory._base_factories
+        )
 
     @classmethod
     def is_batch_factory_type(cls, annotation: Any) -> bool:

--- a/tests/models.py
+++ b/tests/models.py
@@ -25,7 +25,7 @@ class Person(BaseModel):
     birthday: Union[datetime, date]
 
 
-class PersonFactoryWithoutDefaults(ModelFactory):
+class PersonFactoryWithoutDefaults(ModelFactory[Person]):
     __model__ = Person
 
 
@@ -39,5 +39,5 @@ class PersonFactoryWithDefaults(PersonFactoryWithoutDefaults):
     birthday = datetime(2021 - 33, 1, 1)
 
 
-class PetFactory(ModelFactory):
+class PetFactory(ModelFactory[Pet]):
     __model__ = Pet

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -258,7 +258,7 @@ def test_factory_use_construct() -> None:
     # factory should pass values without validation
     invalid_age = "non_valid_age"
     non_validated_pet = PetFactory.build(factory_use_construct=True, age=invalid_age)
-    assert non_validated_pet.age == invalid_age
+    assert non_validated_pet.age == invalid_age  # type: ignore[comparison-overlap]
 
     with pytest.raises(ValidationError):
         PetFactory.build(age=invalid_age)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- `abc.ABC` cannot be instantiated so does not make sense for these to be  considered factory types

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- Closes https://github.com/litestar-org/polyfactory/issues/627
