### PR TITLE
fix(sqla_factory): added an async context manager in SQLAASyncPersistence

### DIFF
--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -52,16 +52,18 @@ class SQLAASyncPersistence(AsyncPersistenceProtocol[T]):
         self.session = session
 
     async def save(self, data: T) -> T:
-        self.session.add(data)
-        await self.session.commit()
-        await self.session.refresh(data)
+        async with self.session as session:
+            session.add(data)
+            await session.commit()
+            await session.refresh(data)
         return data
 
     async def save_many(self, data: list[T]) -> list[T]:
-        self.session.add_all(data)
-        await self.session.commit()
-        for batch_item in data:
-            await self.session.refresh(batch_item)
+        async with self.session as session:
+            session.add_all(data)
+            await session.commit()
+            for batch_item in data:
+                await session.refresh(batch_item)
         return data
 
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- **an async context manager** has been added in SQLAASyncPersistence class to prevent
```bash
...
raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed

The garbage collector is trying to clean up non-checked-in connection <AdaptedConnection <asyncpg.connection.Connection
object>>, which will be terminated.  Please ensure that SQLAlchemy pooled connections are returned to the pool 
explicitly, either by calling ``close()`` or by using appropriate context managers to manage their lifecycle.

sys:1: SAWarning: The garbage collector is trying to clean up non-checked-in connection <AdaptedConnection 
<asyncpg.connection.Connection object>>, which will be terminated.  Please ensure that SQLAlchemy pooled connections are 
returned to the pool explicitly, either by calling ``close()`` or by using appropriate context managers to manage 
their lifecycle.
```

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
- Closes #624 