### PR TITLE
fix(sqla_factory): changed default value for __set_foreign_keys__ attr.

### DIFF
--- a/docs/examples/library_factories/sqlalchemy_factory/test_example_foreign_keys.py
+++ b/docs/examples/library_factories/sqlalchemy_factory/test_example_foreign_keys.py
@@ -1,0 +1,41 @@
+from typing import List
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from polyfactory.factories.sqlalchemy_factory import SQLAlchemyFactory
+
+
+class Base(DeclarativeBase): ...
+
+
+class Author(Base):
+    __tablename__ = "authors"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    books: Mapped[List["Book"]] = relationship("Book", uselist=True)
+
+
+class Book(Base):
+    __tablename__ = "books"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    author_id: Mapped[int] = mapped_column(ForeignKey(Author.id))
+
+
+class BookFactory(SQLAlchemyFactory[Book]): ...
+
+
+class BookFactoryWithForeignKey(SQLAlchemyFactory[Book]):
+    __set_foreign_keys__ = True
+
+
+def test_sqla_factory() -> None:
+    book = BookFactory.build()
+    assert not book.author_id
+
+
+def test_sqla_factory_with_foreign_keys() -> None:
+    book = BookFactoryWithForeignKey.build()
+    assert book.author_id
+    assert isinstance(book.author_id, int)

--- a/docs/usage/library_factories/sqlalchemy_factory.rst
+++ b/docs/usage/library_factories/sqlalchemy_factory.rst
@@ -1,5 +1,5 @@
 SQLAlchemyFactory
-===================
+=================
 
 Basic usage is like other factories
 
@@ -10,8 +10,21 @@ Basic usage is like other factories
 .. note::
     The examples here require SQLAlchemy 2 to be installed. The factory itself supports both 1.4 and 2.
 
+
 Configuration
-------------------------------
+-------------
+
+ForeignKey
+++++++++++
+
+By default, ``__set_foreign_keys__`` is set to ``False``. If it is ``True``, all fields with the SQLAlchemy `ForeignKey <https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKey>`_ will be included in the resulting mock dictionary created by ``build`` method.
+
+.. literalinclude:: /examples/library_factories/sqlalchemy_factory/test_example_foreign_keys.py
+    :caption: Setting foreign_keys
+    :language: python
+
+Relationship
+++++++++++++
 
 By default, relationships will not be set. This can be overridden via ``__set_relationships__``.
 

--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -74,7 +74,7 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
 
     __set_primary_key__: ClassVar[bool] = True
     """Configuration to consider primary key columns as a field or not."""
-    __set_foreign_keys__: ClassVar[bool] = True
+    __set_foreign_keys__: ClassVar[bool] = False
     """Configuration to consider columns with foreign keys as a field or not."""
     __set_relationships__: ClassVar[bool] = False
     """Configuration to consider relationships property as a model field or not."""


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- turned `__set_foreign_keys__` attribute default value to `False`
- added an appropriate part of the docs

## Prerequisites for this changing

Thanks to @adhtruong for https://github.com/litestar-org/polyfactory/issues/624#issuecomment-2591171953
> ... `__set_foreign_keys__` is breaking behaviour. 

and 

>Note a foreign key may be present without a relationship in ORM definition.

My intention would be:

- avoiding redundant factory work
Although a foreign key can be used without a relationship, it is most often paired with a relationship. So a particular factory will be doing sort of a double work because creating foreign field data will be overridden by a relationship.

- consistency in the field logic with `__set_relationships__` and `__set_association_proxy__` (if the last one is added in the future)

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
- Closes #624 