### PR TITLE
fix: allow non-hashable type args

### DIFF
--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, is_dataclass
-from typing import TYPE_CHECKING, Any, Literal, Mapping, Pattern, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Hashable, Literal, Mapping, Pattern, TypedDict, cast
 
 from typing_extensions import get_args, get_origin
 
@@ -93,7 +93,10 @@ class FieldMeta:
 
         :returns: a tuple of types.
         """
-        return tuple(TYPE_MAPPING.get(arg, arg) for arg in get_args(self.annotation))
+        return tuple(
+            TYPE_MAPPING.get(arg, arg) if isinstance(arg, Hashable) else arg  # pyright: ignore[reportCallIssue,reportArgumentType]
+            for arg in get_args(self.annotation)
+        )
 
     @classmethod
     def from_type(

--- a/tests/test_complex_types.py
+++ b/tests/test_complex_types.py
@@ -203,3 +203,13 @@ def test_sequence_dict() -> None:
     result = MyFactory.build()
 
     assert result.sequence_dict
+
+
+def test_build_with_callable() -> None:
+    @dataclass
+    class A:
+        foo: Callable[[str], int]
+
+    factory = DataclassFactory.create_factory(A)
+    with pytest.raises(ParameterException, match="Unsupported type:"):
+        factory.build()


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Allow non-hashable types by checking
- Note this would still raise parameter error in some circumstances but does not raise an internal error allowing the user to specify the way to resolve the type

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

- Closes #639
