### PR TITLE
fix(pyproject.toml): dont allow faker version less then 5.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ readme = "docs/PYPI_README.md"
 license = {text = "MIT"}
 requires-python = ">=3.8,<4.0"
 dependencies = [
-    "faker",
+    "faker>=5.0.0",
     "typing-extensions>=4.6.0",
 ]
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- I've noticed the library is incompatible with low versions of `faker`.
for example, this script won't work

```python
from polyfactory.factories import pydantic_factory
import pydantic

class MyModel(pydantic.BaseModel):
    m_id: int
    name: str

class Factory(pydantic_factory.ModelFactory[MyModel]):
    __model__ = MyModel


print(Factory.build())
```
won't work with version `faker==4.0.0` or lower, due to missing Generator attribute `json`
<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
