### PR TITLE
build: update dependencies and ignores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,15 +27,10 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-  - repo: local
+  - repo: https://github.com/pycontribs/mirrors-prettier
+    rev: "v3.5.2"
     hooks:
       - id: prettier
-        name: prettier
-        entry: prettier --write --ignore-unknown
-        language: node
-        "types": [text]
-        additional_dependencies: ["prettier@3.5.2"]
-        require_serial: false
         exclude: ".all-contributorsrc"
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.15.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: "3.13"
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.6.0
+    rev: v4.0.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
@@ -18,13 +18,13 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.8.1"
+    rev: "v0.9.7"
     hooks:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -33,7 +33,7 @@ repos:
       - id: prettier
         exclude: ".all-contributorsrc"
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.13.0"
+    rev: "v1.15.0"
     hooks:
       - id: mypy
         exclude: "test_decimal_constraints|examples/fields/test_example_2|examples/configuration|tools/"
@@ -52,7 +52,7 @@ repos:
             sqlalchemy>=2,
           ]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.389
+    rev: v1.1.394
     hooks:
       - id: pyright
         exclude: "tests"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,15 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
+  - repo: local
     hooks:
       - id: prettier
+        name: prettier
+        entry: prettier --write --ignore-unknown
+        language: node
+        "types": [text]
+        additional_dependencies: ["prettier@3.5.2"]
+        require_serial: false
         exclude: ".all-contributorsrc"
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.15.0"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ from unittest import mock
 from polyfactory.__metadata__ import __project__, __version__
 
 if TYPE_CHECKING:
-    from sphinx.addnodes import document
+    from sphinx.addnodes import document  # type: ignore[attr-defined]
     from sphinx.application import Sphinx
 
 for mod_name in ("beanie", "odmantic"):

--- a/docs/usage/model_coverage.rst
+++ b/docs/usage/model_coverage.rst
@@ -11,7 +11,7 @@ As you can see in the above example, the ``Profile`` model has 3 options for ``f
 
 
 .. note::
-    Notice that the same ``Car`` instance is used in the first and final generated example. When the coverage examples for a field are exhausted before another field, values for that field are re-used.
+    Notice that the same ``Car`` instance is used in the first and final generated example. When the coverage examples for a field are exhausted before another field, values for that field are reused.
 
 Notes on collection types
 -------------------------

--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -147,7 +147,7 @@ def normalize_annotation(annotation: Any, random: Random) -> Any:
         annotation = unwrap_annotated(annotation, random=random)[0]
 
     # we have to maintain compatibility with the older non-subscriptable typings.
-    if sys.version_info <= (3, 9):  # pragma: no cover
+    if sys.version_info < (3, 9):  # pragma: no cover
         return annotation
 
     origin = get_origin(annotation) or annotation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,9 @@ ignore = [
     "ISC001",  # conflict with formatter
 ]
 
+[tool.ruff.lint.flake8-builtins]
+builtins-allowed-modules = ["types"]
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -46,8 +46,8 @@ def test_register_with_function_error() -> None:
 def test_register_with_class_not_model_factory_error() -> None:
     with pytest.raises(ParameterException):
 
-        @register_fixture  # type: ignore
-        class Foo:
+        @register_fixture
+        class Foo:  # type: ignore[type-var]
             pass
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1251,7 +1251,7 @@ requires-dist = [
     { name = "attrs", marker = "extra == 'full'" },
     { name = "beanie", marker = "extra == 'beanie'" },
     { name = "beanie", marker = "extra == 'full'" },
-    { name = "faker" },
+    { name = "faker", specifier = ">=5.0.0" },
     { name = "msgspec", marker = "extra == 'full'" },
     { name = "msgspec", marker = "extra == 'msgspec'" },
     { name = "odmantic", marker = "extra == 'full'" },


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Update prettier precommit by vendoring in now [archived](https://github.com/pre-commit/mirrors-prettier/tree/main) hook and specifying prettier version here.
- This allows specifying version to one that will be supported by runners. This does have the downside of not being updatable via `pre-commit autoupdate`
- Also in this PR, update other pre-commits and linting fixes required from updates

Edit: changed to using the fork https://github.com/pycontribs/mirrors-prettier which is run by org to maintain such packages so overcomes above issues 

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
