### PR TITLE
feat: improve create factory typing

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -34,7 +34,6 @@ from typing import (
     Hashable,
     Iterable,
     Mapping,
-    Self,
     Sequence,
     Type,
     TypedDict,
@@ -45,7 +44,7 @@ from typing import (
 from uuid import UUID
 
 from faker import Faker
-from typing_extensions import get_args, get_origin, get_original_bases
+from typing_extensions import Self, get_args, get_origin, get_original_bases
 
 from polyfactory.constants import (
     DEFAULT_RANDOM,

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -97,7 +97,11 @@ if TYPE_CHECKING:
 
     from typing_extensions import NotRequired, TypeGuard
 
-T = TypeVar("T", bound="BaseModelV1 | BaseModelV2")  # pyright: ignore[reportInvalidTypeForm]
+    from pydantic import BaseModel
+
+T = TypeVar("T", bound="BaseModel")
+U = TypeVar("U", bound="BaseModel")
+S = TypeVar("S")
 
 _IS_PYDANTIC_V1 = VERSION.startswith("1")
 
@@ -465,7 +469,8 @@ class ModelFactory(Generic[T], BaseFactory[T]):
 
         if "_build_context" not in kwargs:
             kwargs["_build_context"] = PydanticBuildContext(
-                seen_models=set(), factory_use_construct=factory_use_construct
+                seen_models=set(),
+                factory_use_construct=factory_use_construct,
             )
 
         processed_kwargs = cls.process_kwargs(**kwargs)
@@ -502,8 +507,8 @@ class ModelFactory(Generic[T], BaseFactory[T]):
         if cls._get_build_context(_build_context).get("factory_use_construct"):
             if _is_pydantic_v1_model(cls.__model__):
                 return cls.__model__.construct(**kwargs)  # type: ignore[return-value]
-            return cls.__model__.model_construct(**kwargs)  # type: ignore[return-value]
-        return cls.__model__(**kwargs)  # type: ignore[return-value]
+            return cls.__model__.model_construct(**kwargs)
+        return cls.__model__(**kwargs)
 
     @classmethod
     def coverage(cls, factory_use_construct: bool = False, **kwargs: Any) -> abc.Iterator[T]:

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -100,8 +100,6 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
 T = TypeVar("T", bound="BaseModel")
-U = TypeVar("U", bound="BaseModel")
-S = TypeVar("S")
 
 _IS_PYDANTIC_V1 = VERSION.startswith("1")
 

--- a/tests/test_new_types.py
+++ b/tests/test_new_types.py
@@ -160,6 +160,6 @@ class A:
 """,
     )
 
-    factory = DataclassFactory.create_factory(module.A)  # type: ignore[var-annotated]
+    factory = DataclassFactory.create_factory(module.A)
     result = factory.build()
     assert result.field in {"a", "b"}

--- a/tests/test_pydantic_v1_v2.py
+++ b/tests/test_pydantic_v1_v2.py
@@ -49,7 +49,7 @@ def test_build_v1_with_contrained_fields() -> None:
     ConstrainedInt = Annotated[int, Field(ge=100, le=200)]
     ConstrainedStr = Annotated[str, Field(min_length=1, max_length=3)]
 
-    class Foo(pydantic.v1.BaseModel):  # pyright: ignore[reportGeneralTypeIssues]
+    class Foo(BaseModelV1):
         a: ConstrainedInt
         b: ConstrainedStr
         c: Union[ConstrainedInt, ConstrainedStr]
@@ -58,7 +58,7 @@ def test_build_v1_with_contrained_fields() -> None:
         f: List[ConstrainedInt]
         g: Dict[ConstrainedInt, ConstrainedStr]
 
-    ModelFactory.create_factory(Foo).build()  # type: ignore[type-var]
+    ModelFactory.create_factory(Foo).build()
 
 
 def test_build_v2_with_contrained_fields() -> None:

--- a/tests/test_recursive_models.py
+++ b/tests/test_recursive_models.py
@@ -53,7 +53,7 @@ class PydanticNode(BaseModel):
 
 @pytest.mark.parametrize("factory_use_construct", (True, False))
 def test_recursive_pydantic_models(factory_use_construct: bool) -> None:
-    factory = ModelFactory[PydanticNode].create_factory(PydanticNode)
+    factory = ModelFactory.create_factory(PydanticNode)
 
     result = factory.build(factory_use_construct)
     assert result.child is _Sentinel, "Default is not used"  # type: ignore[comparison-overlap]


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- This updates the typing of `create_factory` so bound is with specified model if provided
-  Previously bound was the factory itself only so bound of returned factory was wrong
- Also adds `args` to build which is ignored. This is not ideal but current implementation of `ModelFactory.build` allows providing an arg and unable to match to the specific and this breaks when fixing other issue with bounding properly.
    - I tried fixing this with extra overloads based on if `BaseModel` but this breaks mypy as there are overlapping overloads
    - Longer term may want to remove the arg in ModelFactory but avoiding this for now as a breaking change
- Example of now inferred factory here
<img width="551" alt="Screenshot 2025-03-12 at 13 06 37" src="https://github.com/user-attachments/assets/2625bbc8-6ef8-4e4a-bcdc-7345f5c562c8" />
 

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
