### PR TITLE
fix: ignore dataclass types in pydantic field parsing

### DIFF
--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Hashable, Literal, Mapping, Pattern, TypedDict, cast
 
 from typing_extensions import get_args, get_origin
 
 from polyfactory.constants import DEFAULT_RANDOM, TYPE_MAPPING
 from polyfactory.utils.deprecation import check_for_deprecated_parameters
-from polyfactory.utils.helpers import get_annotation_metadata, unwrap_annotated, unwrap_new_type
+from polyfactory.utils.helpers import get_annotation_metadata, is_dataclass_instance, unwrap_annotated, unwrap_new_type
 from polyfactory.utils.predicates import is_annotated
 from polyfactory.utils.types import NoneType
 
@@ -181,7 +181,7 @@ class FieldMeta:
                     constraints["pattern"] = "[[:ascii:]]"
                 elif func is str.isdigit:
                     constraints["pattern"] = "[[:digit:]]"
-            elif is_dataclass(value) and (value_dict := asdict(value)) and ("allowed_schemes" in value_dict):  # type: ignore[arg-type]
+            elif is_dataclass_instance(value) and (value_dict := asdict(value)) and ("allowed_schemes" in value_dict):
                 constraints["url"] = {k: v for k, v in value_dict.items() if v is not None}
             # This is to support `Constraints`, but we can't do a isinstance with `Constraints` since isinstance
             # checks with `TypedDict` is not supported.

--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from collections import deque
+from dataclasses import is_dataclass
 from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 from typing_extensions import TypeAliasType, get_args, get_origin
@@ -198,3 +199,7 @@ def get_collection_type(annotation: Any) -> type[list | tuple | set | frozenset 
 
     msg = f"Unknown collection type - {annotation}"
     raise ValueError(msg)
+
+
+def is_dataclass_instance(obj: Any) -> bool:
+    return is_dataclass(obj) and not isinstance(obj, type)

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -1038,3 +1038,12 @@ def test_annotated_children() -> None:
     AFactory = ModelFactory.create_factory(A)
 
     assert AFactory.build()
+
+
+@pytest.mark.skipif(IS_PYDANTIC_V1, reason="pydantic 2 only test")
+def test_skip_validation() -> None:
+    class A(BaseModel):
+        a: Annotated[int, pydantic.SkipValidation]
+
+    AFactory = ModelFactory.create_factory(A)
+    assert AFactory.build()


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- See title

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Fixes https://github.com/litestar-org/polyfactory/issues/658
