### PR TITLE
refactor: deprecate FieldMeta.random

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,8 @@ install:											## Install the project, dependencies, and pre-commit for loca
 .PHONY: clean
 clean: 												## Cleanup temporary build artifacts
 	@echo "=> Cleaning working directory"
-	@rm -rf .pytest_cache .ruff_cache .hypothesis build/ dist/ .eggs/
+	@rm -rf .pytest_cache .ruff_cache .hypothesis build/ dist/ .eggs/ .egg/
 	@find . -name '*.egg-info' -exec rm -rf {} +
-	@find . -name '*.egg' -exec rm -f {} +
 	@find . -name '*.pyc' -exec rm -f {} +
 	@find . -name '*.pyo' -exec rm -f {} +
 	@find . -name '*~' -exec rm -f {} +

--- a/polyfactory/collection_extender.py
+++ b/polyfactory/collection_extender.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from collections import deque
 from typing import Any
 
+from polyfactory.utils.deprecation import deprecated
 from polyfactory.utils.predicates import is_safe_subclass
 
 
@@ -28,6 +29,7 @@ class CollectionExtender(ABC):
         )
 
     @classmethod
+    @deprecated("2.20.0")
     def extend_type_args(
         cls,
         annotation_alias: Any,

--- a/polyfactory/factories/attrs_factory.py
+++ b/polyfactory/factories/attrs_factory.py
@@ -65,7 +65,6 @@ class AttrsFactory(Generic[T], BaseFactory[T]):
                     annotation=annotation,
                     name=field.alias,
                     default=default_value,
-                    random=cls.__random__,
                 ),
             )
 

--- a/polyfactory/factories/dataclass_factory.py
+++ b/polyfactory/factories/dataclass_factory.py
@@ -51,7 +51,6 @@ class DataclassFactory(Generic[T], BaseFactory[T]):
                     annotation=model_type_hints[field.name],
                     name=field.name,
                     default=default_value,
-                    random=cls.__random__,
                 ),
             )
 

--- a/polyfactory/factories/msgspec_factory.py
+++ b/polyfactory/factories/msgspec_factory.py
@@ -66,7 +66,6 @@ class MsgspecFactory(Generic[T], BaseFactory[T]):
                     annotation=annotation,
                     name=field.name,
                     default=default_value,
-                    random=cls.__random__,
                 ),
             )
         return fields_meta

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -331,16 +331,15 @@ class PydanticFieldMeta(FieldMeta):
                 )
                 for sub_field in fields_to_iterate
             )
-            type_arg_to_sub_field = dict(zip(type_args, fields_to_iterate))
             if get_origin(outer_type) in (tuple, Tuple) and get_args(outer_type)[-1] == Ellipsis:
                 # pydantic removes ellipses from Tuples in sub_fields
                 type_args += (...,)
             children.extend(
                 PydanticFieldMeta.from_model_field(
-                    model_field=type_arg_to_sub_field[arg],
+                    model_field=arg,
                     use_alias=use_alias,
                 )
-                for arg in type_args
+                for arg in fields_to_iterate
             )
 
         return PydanticFieldMeta(

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -11,8 +11,6 @@ from uuid import NAMESPACE_DNS, uuid1, uuid3, uuid5
 
 from typing_extensions import Literal, get_args, get_origin
 
-from polyfactory.collection_extender import CollectionExtender
-from polyfactory.constants import DEFAULT_RANDOM
 from polyfactory.exceptions import MissingDependencyException
 from polyfactory.factories.base import BaseFactory, BuildContext
 from polyfactory.factories.base import BuildContext as BaseBuildContext
@@ -142,7 +140,7 @@ class PydanticFieldMeta(FieldMeta):
         field_name: str,
         field_info: FieldInfo,
         use_alias: bool,
-        random: Random | None,
+        random: Random | None = None,
         randomize_collection_length: bool | None = None,
         min_collection_length: int | None = None,
         max_collection_length: int | None = None,
@@ -165,6 +163,7 @@ class PydanticFieldMeta(FieldMeta):
                 ("randomize_collection_length", randomize_collection_length),
                 ("min_collection_length", min_collection_length),
                 ("max_collection_length", max_collection_length),
+                ("random", random),
             ),
         )
         if callable(field_info.default_factory):
@@ -191,7 +190,6 @@ class PydanticFieldMeta(FieldMeta):
                         field_name="",
                         field_info=merged_field_info,
                         use_alias=use_alias,
-                        random=random,
                     ),
                 )
         else:
@@ -220,7 +218,6 @@ class PydanticFieldMeta(FieldMeta):
             constraints=cast("Constraints", {k: v for k, v in constraints.items() if v is not None}) or None,
             default=default_value,
             name=name,
-            random=random or DEFAULT_RANDOM,
         )
 
     @classmethod
@@ -231,7 +228,7 @@ class PydanticFieldMeta(FieldMeta):
         randomize_collection_length: bool | None = None,
         min_collection_length: int | None = None,
         max_collection_length: int | None = None,
-        random: Random = DEFAULT_RANDOM,
+        random: Random | None = None,
     ) -> PydanticFieldMeta:
         """Create an instance from a pydantic model field.
         :param model_field: A pydantic ModelField.
@@ -250,6 +247,7 @@ class PydanticFieldMeta(FieldMeta):
                 ("randomize_collection_length", randomize_collection_length),
                 ("min_collection_length", min_collection_length),
                 ("max_collection_length", max_collection_length),
+                ("random", random),
             ),
         )
 
@@ -337,19 +335,16 @@ class PydanticFieldMeta(FieldMeta):
             if get_origin(outer_type) in (tuple, Tuple) and get_args(outer_type)[-1] == Ellipsis:
                 # pydantic removes ellipses from Tuples in sub_fields
                 type_args += (...,)
-            extended_type_args = CollectionExtender.extend_type_args(annotation, type_args, 1)
             children.extend(
                 PydanticFieldMeta.from_model_field(
                     model_field=type_arg_to_sub_field[arg],
                     use_alias=use_alias,
-                    random=random,
                 )
-                for arg in extended_type_args
+                for arg in type_args
             )
 
         return PydanticFieldMeta(
             name=name,
-            random=random or DEFAULT_RANDOM,
             annotation=annotation,  # pyright: ignore[reportArgumentType]
             children=children or None,
             default=default_value,
@@ -411,7 +406,6 @@ class ModelFactory(Generic[T], BaseFactory[T]):
                     PydanticFieldMeta.from_model_field(
                         field,
                         use_alias=not cls.__model__.__config__.allow_population_by_field_name,  # type: ignore[attr-defined]
-                        random=cls.__random__,
                     )
                     for field in cls.__model__.__fields__.values()
                 ]
@@ -420,7 +414,6 @@ class ModelFactory(Generic[T], BaseFactory[T]):
                     PydanticFieldMeta.from_field_info(
                         field_info=field_info,
                         field_name=field_name,
-                        random=cls.__random__,
                         use_alias=not cls.__model__.model_config.get(  # pyright: ignore[reportGeneralTypeIssues]
                             "populate_by_name",
                             False,

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -6,10 +6,10 @@ from datetime import timezone
 from functools import partial
 from os.path import realpath
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, ForwardRef, Generic, Mapping, Tuple, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, ForwardRef, Generic, Mapping, TypeVar, cast
 from uuid import NAMESPACE_DNS, uuid1, uuid3, uuid5
 
-from typing_extensions import Literal, get_args, get_origin
+from typing_extensions import Literal, get_args
 
 from polyfactory.exceptions import MissingDependencyException
 from polyfactory.factories.base import BaseFactory, BuildContext
@@ -308,7 +308,7 @@ class PydanticFieldMeta(FieldMeta):
         if model_field.field_info.const and (
             default_value is None or isinstance(default_value, (int, bool, str, bytes))
         ):
-            annotation = Literal[default_value]  # pyright: ignore  # noqa: PGH003
+            annotation = Literal[default_value]
 
         children: list[FieldMeta] = []
 
@@ -323,17 +323,6 @@ class PydanticFieldMeta(FieldMeta):
                 if model_field.key_field is not None
                 else model_field.sub_fields
             )
-            type_args = tuple(
-                (
-                    sub_field.outer_type_
-                    if isinstance(sub_field.annotation, DeferredType)
-                    else unwrap_new_type(sub_field.annotation)
-                )
-                for sub_field in fields_to_iterate
-            )
-            if get_origin(outer_type) in (tuple, Tuple) and get_args(outer_type)[-1] == Ellipsis:
-                # pydantic removes ellipses from Tuples in sub_fields
-                type_args += (...,)
             children.extend(
                 PydanticFieldMeta.from_model_field(
                     model_field=arg,

--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -214,7 +214,6 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
             FieldMeta.from_type(
                 annotation=cls.get_type_from_column(column),
                 name=name,
-                random=cls.__random__,
             )
             for name, column in table.columns.items()
             if cls.should_column_be_set(column)
@@ -227,7 +226,6 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
                     FieldMeta.from_type(
                         name=name,
                         annotation=annotation,
-                        random=cls.__random__,
                     ),
                 )
         if cls.__set_association_proxy__:
@@ -244,7 +242,6 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
                                 FieldMeta.from_type(
                                     name=name,
                                     annotation=annotation,
-                                    random=cls.__random__,
                                 )
                             )
 

--- a/polyfactory/factories/typed_dict_factory.py
+++ b/polyfactory/factories/typed_dict_factory.py
@@ -12,7 +12,6 @@ from typing_extensions import (  # type: ignore[attr-defined]
     is_typeddict,
 )
 
-from polyfactory.constants import DEFAULT_RANDOM
 from polyfactory.factories.base import BaseFactory
 from polyfactory.field_meta import FieldMeta, Null
 
@@ -52,7 +51,6 @@ class TypedDictFactory(Generic[TypedDictT], BaseFactory[TypedDictT]):
             field_metas.append(
                 FieldMeta.from_type(
                     annotation=annotation,
-                    random=DEFAULT_RANDOM,
                     name=field_name,
                     default=getattr(cls.__model__, field_name, Null),
                 ),

--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -80,6 +80,7 @@ class FieldMeta:
         constraints: Constraints | None = None,
     ) -> None:
         """Create a factory field metadata instance."""
+        check_for_deprecated_parameters("2.20.0", parameters=(("random", random),))
         self.annotation = annotation
         self.random = random or DEFAULT_RANDOM
         self.children = children
@@ -102,7 +103,7 @@ class FieldMeta:
     def from_type(
         cls,
         annotation: Any,
-        random: Random = DEFAULT_RANDOM,
+        random: Random | None = None,
         name: str = "",
         default: Any = Null,
         constraints: Constraints | None = None,
@@ -130,6 +131,7 @@ class FieldMeta:
                 ("randomize_collection_length", randomize_collection_length),
                 ("min_collection_length", min_collection_length),
                 ("max_collection_length", max_collection_length),
+                ("random", random),
             ),
         )
 
@@ -146,7 +148,6 @@ class FieldMeta:
 
         field = cls(
             annotation=annotation,
-            random=random,
             name=name,
             default=default,
             children=children,
@@ -155,12 +156,7 @@ class FieldMeta:
 
         if field.type_args and not field.children:
             field.children = [
-                cls.from_type(
-                    annotation=unwrap_new_type(arg),
-                    random=random,
-                )
-                for arg in field.type_args
-                if arg is not NoneType
+                cls.from_type(annotation=unwrap_new_type(arg)) for arg in field.type_args if arg is not NoneType
             ]
         return field
 

--- a/polyfactory/value_generators/constrained_numbers.py
+++ b/polyfactory/value_generators/constrained_numbers.py
@@ -432,7 +432,7 @@ def handle_constrained_decimal(
     )
 
     if max_digits is not None:
-        validate_max_digits(max_digits=max_digits, minimum=minimum, decimal_places=decimal_places)
+        validate_max_digits(max_digits=max_digits, minimum=None, decimal_places=decimal_places)
 
     generated_decimal = generate_constrained_number(
         random=random,

--- a/tests/constraints/test_frozen_set_constraints.py
+++ b/tests/constraints/test_frozen_set_constraints.py
@@ -1,5 +1,4 @@
 from contextlib import suppress
-from random import Random
 from typing import Any
 
 import pytest
@@ -23,7 +22,7 @@ def test_handle_constrained_set_with_min_items_and_max_items(min_items: int, max
         result = handle_constrained_collection(
             collection_type=frozenset,
             factory=ModelFactory,
-            field_meta=FieldMeta(name="test", annotation=frozenset, random=Random()),
+            field_meta=FieldMeta(name="test", annotation=frozenset),
             item_type=str,
             max_items=max_items,
             min_items=min_items,
@@ -35,7 +34,7 @@ def test_handle_constrained_set_with_min_items_and_max_items(min_items: int, max
             handle_constrained_collection(
                 collection_type=frozenset,
                 factory=ModelFactory,
-                field_meta=FieldMeta(name="test", annotation=frozenset, random=Random()),
+                field_meta=FieldMeta(name="test", annotation=frozenset),
                 item_type=str,
                 max_items=max_items,
                 min_items=min_items,
@@ -51,7 +50,7 @@ def test_handle_constrained_set_with_max_items(
     result = handle_constrained_collection(
         collection_type=frozenset,
         factory=ModelFactory,
-        field_meta=FieldMeta(name="test", annotation=frozenset, random=Random()),
+        field_meta=FieldMeta(name="test", annotation=frozenset),
         item_type=str,
         max_items=max_items,
     )
@@ -67,7 +66,7 @@ def test_handle_constrained_set_with_min_items(
     result = handle_constrained_collection(
         collection_type=frozenset,
         factory=ModelFactory,
-        field_meta=FieldMeta(name="test", annotation=frozenset, random=Random()),
+        field_meta=FieldMeta(name="test", annotation=frozenset),
         item_type=str,
         min_items=min_items,
     )
@@ -80,7 +79,7 @@ def test_handle_constrained_set_with_different_types(t_type: Any) -> None:
         result = handle_constrained_collection(
             collection_type=frozenset,
             factory=ModelFactory,
-            field_meta=FieldMeta(name="test", annotation=frozenset, random=Random()),
+            field_meta=FieldMeta(name="test", annotation=frozenset),
             item_type=t_type,
         )
         assert len(result) >= 0

--- a/tests/constraints/test_get_field_value_constraints.py
+++ b/tests/constraints/test_get_field_value_constraints.py
@@ -1,6 +1,5 @@
 from datetime import date, datetime, timedelta
 from decimal import Decimal
-from random import Random
 from typing import FrozenSet, List, Set, Tuple, Type, Union, cast
 
 import pytest
@@ -13,7 +12,7 @@ from polyfactory.field_meta import Constraints, FieldMeta
 @pytest.mark.parametrize("t", (int, float, Decimal))
 def test_numbers(t: Type[Union[int, float, Decimal]]) -> None:
     constraints: Constraints = {"ge": 1, "le": 20}
-    field_meta = FieldMeta.from_type(annotation=t, name="foo", constraints=constraints, random=Random())
+    field_meta = FieldMeta.from_type(annotation=t, name="foo", constraints=constraints)
     value = BaseFactory.get_field_value(field_meta)
 
     assert value >= constraints["ge"]
@@ -23,7 +22,7 @@ def test_numbers(t: Type[Union[int, float, Decimal]]) -> None:
 @pytest.mark.parametrize("t", (str, bytes))
 def test_str_and_bytes(t: Type[Union[str, bytes]]) -> None:
     constraints: Constraints = {"min_length": 20, "max_length": 45}
-    field_meta = FieldMeta.from_type(annotation=t, name="foo", constraints=constraints, random=Random())
+    field_meta = FieldMeta.from_type(annotation=t, name="foo", constraints=constraints)
     value = BaseFactory.get_field_value(field_meta)
 
     assert len(value) >= constraints["min_length"]
@@ -36,7 +35,7 @@ def test_collections(t: Type[Union[Tuple, List, Set, FrozenSet]]) -> None:
         "min_length": 2,
         "max_length": 10,
     }
-    field_meta = FieldMeta.from_type(annotation=t, name="foo", constraints=constraints, random=Random())
+    field_meta = FieldMeta.from_type(annotation=t, name="foo", constraints=constraints)
     value = BaseFactory.get_field_value(field_meta)
 
     assert len(value) >= constraints["min_length"]
@@ -52,7 +51,6 @@ def test_date() -> None:
         annotation=date,
         name="foo",
         constraints=cast(Constraints, constraints),
-        random=Random(),
     )
     value = BaseFactory.get_field_value(field_meta)
 

--- a/tests/constraints/test_list_constraints.py
+++ b/tests/constraints/test_list_constraints.py
@@ -1,5 +1,4 @@
 import sys
-from random import Random
 from typing import Any, List
 
 import pytest
@@ -25,7 +24,7 @@ def test_handle_constrained_list_with_min_items_and_max_items(min_items: int, ma
         result = handle_constrained_collection(
             collection_type=list,
             factory=ModelFactory,
-            field_meta=FieldMeta(name="test", annotation=list, random=Random()),
+            field_meta=FieldMeta(name="test", annotation=list),
             item_type=str,
             max_items=max_items,
             min_items=min_items,
@@ -37,7 +36,7 @@ def test_handle_constrained_list_with_min_items_and_max_items(min_items: int, ma
             handle_constrained_collection(
                 collection_type=list,
                 factory=ModelFactory,
-                field_meta=FieldMeta(name="test", annotation=list, random=Random()),
+                field_meta=FieldMeta(name="test", annotation=list),
                 item_type=str,
                 max_items=max_items,
                 min_items=min_items,
@@ -53,7 +52,7 @@ def test_handle_constrained_list_with_max_items(
     result = handle_constrained_collection(
         collection_type=list,
         factory=ModelFactory,
-        field_meta=FieldMeta(name="test", annotation=list, random=Random()),
+        field_meta=FieldMeta(name="test", annotation=list),
         item_type=str,
         max_items=max_items,
     )
@@ -69,7 +68,7 @@ def test_handle_constrained_list_with_min_items(
     result = handle_constrained_collection(
         collection_type=list,
         factory=ModelFactory,
-        field_meta=FieldMeta.from_type(List[str], name="test", random=Random()),
+        field_meta=FieldMeta.from_type(List[str], name="test"),
         item_type=str,
         min_items=min_items,
     )
@@ -82,7 +81,7 @@ def test_handle_constrained_list_with_min_items(
 )
 @pytest.mark.parametrize("t_type", tuple(ModelFactory.get_provider_map()))
 def test_handle_constrained_list_with_different_types(t_type: Any) -> None:
-    field_meta = FieldMeta.from_type(List[t_type], name="test", random=Random())
+    field_meta = FieldMeta.from_type(List[t_type], name="test")
     result = handle_constrained_collection(
         collection_type=list,
         factory=ModelFactory,
@@ -93,7 +92,7 @@ def test_handle_constrained_list_with_different_types(t_type: Any) -> None:
 
 
 def test_handle_unique_items() -> None:
-    field_meta = FieldMeta.from_type(List[str], name="test", random=Random(), constraints={"unique_items": True})
+    field_meta = FieldMeta.from_type(List[str], name="test", constraints={"unique_items": True})
     result = handle_constrained_collection(
         collection_type=list,
         factory=ModelFactory,

--- a/tests/constraints/test_mapping_constraints.py
+++ b/tests/constraints/test_mapping_constraints.py
@@ -1,5 +1,3 @@
-from random import Random
-
 import pytest
 from hypothesis import given
 from hypothesis.strategies import integers
@@ -17,10 +15,9 @@ from polyfactory.value_generators.constrained_collections import (
     integers(min_value=0, max_value=10),
 )
 def test_handle_constrained_mapping_with_min_items_and_max_items(min_items: int, max_items: int) -> None:
-    random = Random()
-    key_field = FieldMeta(name="key", annotation=str, random=random)
-    value_field = FieldMeta(name="value", annotation=int, random=random)
-    field_meta = FieldMeta(name="test", annotation=dict, children=[key_field, value_field], random=random)
+    key_field = FieldMeta(name="key", annotation=str)
+    value_field = FieldMeta(name="value", annotation=int)
+    field_meta = FieldMeta(name="test", annotation=dict, children=[key_field, value_field])
 
     if max_items >= min_items:
         result = handle_constrained_mapping(
@@ -45,16 +42,14 @@ def test_handle_constrained_mapping_with_min_items_and_max_items(min_items: int,
 
 
 def test_handle_constrained_mapping_with_constrained_key_and_value() -> None:
-    random = Random()
-
     key_min_length = 5
     value_gt = 100
     min_length = 5
     max_length = 10
 
-    key_field = FieldMeta(name="key", annotation=str, random=random, constraints={"min_length": key_min_length})
-    value_field = FieldMeta(name="value", annotation=int, random=random, constraints={"gt": value_gt})
-    field_meta = FieldMeta(name="test", annotation=dict, children=[key_field, value_field], random=random)
+    key_field = FieldMeta(name="key", annotation=str, constraints={"min_length": key_min_length})
+    value_field = FieldMeta(name="value", annotation=int, constraints={"gt": value_gt})
+    field_meta = FieldMeta(name="test", annotation=dict, children=[key_field, value_field])
 
     result = handle_constrained_mapping(
         factory=ModelFactory,

--- a/tests/constraints/test_set_constraints.py
+++ b/tests/constraints/test_set_constraints.py
@@ -1,5 +1,4 @@
 from contextlib import suppress
-from random import Random
 from typing import Any
 
 import pytest
@@ -23,7 +22,7 @@ def test_handle_constrained_set_with_min_items_and_max_items(min_items: int, max
         result = handle_constrained_collection(
             collection_type=list,
             factory=ModelFactory,
-            field_meta=FieldMeta(name="test", annotation=set, random=Random()),
+            field_meta=FieldMeta(name="test", annotation=set),
             item_type=str,
             max_items=max_items,
             min_items=min_items,
@@ -35,7 +34,7 @@ def test_handle_constrained_set_with_min_items_and_max_items(min_items: int, max
             handle_constrained_collection(
                 collection_type=list,
                 factory=ModelFactory,
-                field_meta=FieldMeta(name="test", annotation=set, random=Random()),
+                field_meta=FieldMeta(name="test", annotation=set),
                 item_type=str,
                 max_items=max_items,
                 min_items=min_items,
@@ -51,7 +50,7 @@ def test_handle_constrained_set_with_max_items(
     result = handle_constrained_collection(
         collection_type=list,
         factory=ModelFactory,
-        field_meta=FieldMeta(name="test", annotation=set, random=Random()),
+        field_meta=FieldMeta(name="test", annotation=set),
         item_type=str,
         max_items=max_items,
     )
@@ -67,7 +66,7 @@ def test_handle_constrained_set_with_min_items(
     result = handle_constrained_collection(
         collection_type=list,
         factory=ModelFactory,
-        field_meta=FieldMeta(name="test", annotation=set, random=Random()),
+        field_meta=FieldMeta(name="test", annotation=set),
         item_type=str,
         min_items=min_items,
     )
@@ -80,7 +79,7 @@ def test_handle_constrained_set_with_different_types(t_type: Any) -> None:
         result = handle_constrained_collection(
             collection_type=list,
             factory=ModelFactory,
-            field_meta=FieldMeta(name="test", annotation=set, random=Random()),
+            field_meta=FieldMeta(name="test", annotation=set),
             item_type=t_type,
         )
         assert len(result) >= 0

--- a/tests/test_pydantic_v1_v2.py
+++ b/tests/test_pydantic_v1_v2.py
@@ -1,6 +1,6 @@
 """Tests to check that usage of pydantic v1 and v2 at the same time works."""
 
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional, Tuple, Type, Union
 
 import pytest
 from typing_extensions import Annotated
@@ -77,3 +77,16 @@ def test_build_v2_with_contrained_fields() -> None:
         g: Dict[ConstrainedInt, ConstrainedStr]
 
     ModelFactory.create_factory(Foo).build()
+
+
+def test_variadic_tuple_length() -> None:
+    class Foo(pydantic.BaseModel):
+        bar: Tuple[int, ...]
+
+    class Factory(ModelFactory[Foo]):
+        __randomize_collection_length__ = True
+        __min_collection_length__ = 7
+        __max_collection_length__ = 8
+
+    result = Factory.build()
+    assert 7 <= len(result.bar) <= 8


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Deprecate `FieldMeta.random`. This is unused and keeps this class stateless
- Simplify pydantic meta. Some edge cases here look handled elsewhere so redundant to handle here too
- Deprecate `CollectionExtender` too. This was only used in `FieldMeta` so no longer needed

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
