### PR TITLE
chore: deprecate random in helpers

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -448,7 +448,7 @@ class BaseFactory(ABC, Generic[T]):
         :returns: Boolean dictating whether the annotation is a batch factory type
         """
         origin = get_type_origin(annotation) or annotation
-        if is_safe_subclass(origin, Sequence) and (args := unwrap_args(annotation, random=cls.__random__)):
+        if is_safe_subclass(origin, Sequence) and (args := unwrap_args(annotation)):
             return len(args) == 1 and BaseFactory.is_factory_type(annotation=args[0])
         return False
 
@@ -748,7 +748,7 @@ class BaseFactory(ABC, Generic[T]):
         if field_build_parameters is None and cls.should_set_none_value(field_meta=field_meta):
             return None
 
-        unwrapped_annotation = unwrap_annotation(field_meta.annotation, random=cls.__random__)
+        unwrapped_annotation = unwrap_annotation(field_meta.annotation)
 
         if is_literal(annotation=unwrapped_annotation) and (literal_args := get_args(unwrapped_annotation)):
             return cls.__random__.choice(literal_args)

--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Sequence
 from typing_extensions import TypeAliasType, get_args, get_origin
 
 from polyfactory.constants import TYPE_MAPPING
+from polyfactory.utils.deprecation import check_for_deprecated_parameters, deprecated
 from polyfactory.utils.predicates import is_annotated, is_new_type, is_optional, is_safe_subclass, is_union
 from polyfactory.utils.types import NoneType
 
@@ -28,6 +29,7 @@ def unwrap_new_type(annotation: Any) -> Any:
     return annotation
 
 
+@deprecated("v2.21.0")
 def unwrap_union(annotation: Any, random: Random) -> Any:
     """Unwraps union types - recursively.
 
@@ -53,7 +55,7 @@ def unwrap_optional(annotation: Any) -> Any:
     return annotation
 
 
-def unwrap_annotation(annotation: Any, random: Random) -> Any:
+def unwrap_annotation(annotation: Any, random: Random | None = None) -> Any:
     """Unwraps an annotation.
 
     :param annotation: A type annotation.
@@ -62,9 +64,9 @@ def unwrap_annotation(annotation: Any, random: Random) -> Any:
     :returns: The unwrapped annotation.
 
     """
+    check_for_deprecated_parameters("v2.21.0", parameters=(("random", random),))
     while (
         is_optional(annotation)
-        or is_union(annotation)
         or is_new_type(annotation)
         or is_annotated(annotation)
         or isinstance(annotation, TypeAliasType)
@@ -74,11 +76,9 @@ def unwrap_annotation(annotation: Any, random: Random) -> Any:
         elif is_optional(annotation):
             annotation = unwrap_optional(annotation)
         elif is_annotated(annotation):
-            annotation = unwrap_annotated(annotation, random=random)[0]
-        elif isinstance(annotation, TypeAliasType):
-            annotation = annotation.__value__
+            annotation = unwrap_annotated(annotation)[0]
         else:
-            annotation = unwrap_union(annotation, random=random)
+            annotation = annotation.__value__
 
     return annotation
 
@@ -107,7 +107,7 @@ def flatten_annotation(annotation: Any) -> list[Any]:
     return flat
 
 
-def unwrap_args(annotation: Any, random: Random) -> tuple[Any, ...]:
+def unwrap_args(annotation: Any, random: Random | None = None) -> tuple[Any, ...]:
     """Unwrap the annotation and return any type args.
 
     :param annotation: A type annotation
@@ -116,11 +116,11 @@ def unwrap_args(annotation: Any, random: Random) -> tuple[Any, ...]:
     :returns: A tuple of type args.
 
     """
+    check_for_deprecated_parameters("v2.21.0", parameters=(("random", random),))
+    return get_args(unwrap_annotation(annotation=annotation))
 
-    return get_args(unwrap_annotation(annotation=annotation, random=random))
 
-
-def unwrap_annotated(annotation: Any, random: Random) -> tuple[Any, list[Any]]:
+def unwrap_annotated(annotation: Any, random: Random | None = None) -> tuple[Any, list[Any]]:
     """Unwrap an annotated type and return a tuple of type args and optional metadata.
 
     :param annotation: An annotated type annotation
@@ -129,10 +129,12 @@ def unwrap_annotated(annotation: Any, random: Random) -> tuple[Any, list[Any]]:
     :returns: A tuple of type args.
 
     """
+    check_for_deprecated_parameters("v2.21.0", parameters=(("random", random),))
     args = [arg for arg in get_args(annotation) if arg is not None]
-    return unwrap_annotation(args[0], random=random), args[1:]
+    return unwrap_annotation(args[0]), args[1:]
 
 
+@deprecated("v2.21.0")
 def normalize_annotation(annotation: Any, random: Random) -> Any:
     """Normalize an annotation.
 

--- a/polyfactory/utils/predicates.py
+++ b/polyfactory/utils/predicates.py
@@ -9,6 +9,7 @@ from typing_extensions import (
     ParamSpec,
     Required,
     TypeGuard,
+    TypeIs,
     _AnnotatedAlias,
     get_origin,
 )
@@ -70,7 +71,7 @@ def is_union(annotation: Any) -> "TypeGuard[Any]":
     return get_type_origin(annotation) in UNION_TYPES
 
 
-def is_optional(annotation: Any) -> "TypeGuard[Any | None]":
+def is_optional(annotation: Any) -> "TypeIs[None]":
     """Determine whether a given annotation is 'typing.Optional'.
 
     :param annotation: A type annotation.
@@ -95,7 +96,7 @@ def is_literal(annotation: Any) -> bool:
     )
 
 
-def is_new_type(annotation: Any) -> "TypeGuard[type[NewType]]":
+def is_new_type(annotation: Any) -> "TypeIs[type[NewType]]":
     """Determine whether a given annotation is 'typing.NewType'.
 
     :param annotation: A type annotation.


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Deprecate `random` as an arg. Largely used as to pass on or for union handling. Union handling is done in `Basefactory.get_field_value` already so redundant to do here
- Deprecate unused functions

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
