### PR TITLE
feat: optionally pass args to provider function

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -836,6 +836,15 @@ class BaseFactory(ABC, Generic[T]):
             )
 
         if provider := cls.get_provider_map().get(unwrapped_annotation):
+            provider_signature = inspect.signature(provider)
+
+            def has_provider_args(method: Callable):
+                params = inspect.signature(method).parameters
+                return len(params) == 2 and "cls" in params and "field_meta" in params
+
+            if has_provider_args(provider):
+                return provider(cls, field_meta)
+
             return provider()
 
         if isinstance(unwrapped_annotation, TypeVar):


### PR DESCRIPTION
## Description

Right now, a provider has no context about the class or field in question. Most of the time, that's fine.

In my scenario, I am generating TypeIDs which are prefixed with a specific string tied to a particular field name ([more details](https://github.com/iloveitaly/activemodel?tab=readme-ov-file#typeid).
This requires the context of the field and model to determine a good random ID.

This change passes in the model and field meta into the provider, if the provider function accepts the right arguments with the right names.

## Closes
