### PR TITLE
feat: NeverNone to always generate an optional field

### DIFF
--- a/polyfactory/__init__.py
+++ b/polyfactory/__init__.py
@@ -1,6 +1,6 @@
 from .exceptions import ConfigurationException
 from .factories import BaseFactory
-from .fields import Fixture, Ignore, PostGenerated, Require, Use
+from .fields import Fixture, Ignore, PostGenerated, Require, Use, NeverNone
 from .persistence import AsyncPersistenceProtocol, SyncPersistenceProtocol
 
 __all__ = (
@@ -11,6 +11,7 @@ __all__ = (
     "Ignore",
     "PostGenerated",
     "Require",
+    "NeverNone",
     "SyncPersistenceProtocol",
     "Use",
 )

--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -54,7 +54,7 @@ from polyfactory.constants import (
 )
 from polyfactory.exceptions import ConfigurationException, MissingBuildKwargException, ParameterException
 from polyfactory.field_meta import Null
-from polyfactory.fields import Fixture, Ignore, PostGenerated, Require, Use
+from polyfactory.fields import Fixture, Ignore, NeverNone, PostGenerated, Require, Use
 from polyfactory.utils.helpers import (
     flatten_annotation,
     get_collection_type,
@@ -334,6 +334,7 @@ class BaseFactory(ABC, Generic[T]):
         if isinstance(field_value, Fixture):
             return field_value.to_value()
 
+        # if a raw lambda is passed, invoke it
         if callable(field_value):
             return field_value()
 
@@ -942,8 +943,12 @@ class BaseFactory(ABC, Generic[T]):
         :returns: A boolean determining whether 'None' should be set for the given field_meta.
 
         """
+        field_value = hasattr(cls, field_meta.name) and getattr(cls, field_meta.name)
+        never_none = field_value and isinstance(field_value, NeverNone)
+
         return (
             cls.__allow_none_optionals__
+            and not never_none
             and is_optional(field_meta.annotation)
             and create_random_boolean(random=cls.__random__)
         )
@@ -1017,12 +1022,14 @@ class BaseFactory(ABC, Generic[T]):
                 f"{field_name} is declared on the factory {cls.__name__}"
                 f" but it is not part of the model {cls.__model__.__name__}"
             )
-            if isinstance(field_value, (Use, PostGenerated, Ignore, Require)):
+            if isinstance(field_value, (Use, PostGenerated, Ignore, Require, NeverNone)):
                 raise ConfigurationException(error_message)
 
     @classmethod
     def process_kwargs(cls, **kwargs: Any) -> dict[str, Any]:
         """Process the given kwargs and generate values for the factory's model.
+
+        If you need to deeply customize field values, you'll want to override this method.
 
         :param kwargs: Any build kwargs.
 
@@ -1034,8 +1041,11 @@ class BaseFactory(ABC, Generic[T]):
         for field_meta in cls.get_model_fields():
             field_build_parameters = cls.extract_field_build_parameters(field_meta=field_meta, build_args=kwargs)
             if cls.should_set_field_value(field_meta, **kwargs) and not cls.should_use_default_value(field_meta):
-                if hasattr(cls, field_meta.name) and not hasattr(BaseFactory, field_meta.name):
-                    field_value = getattr(cls, field_meta.name)
+                field_value = getattr(cls, field_meta.name, None)
+
+                # TODO why do we need the BaseFactory check here, only dunder methods which are ignored would trigger this?
+                # NeverNone should be treated as a normally-generated field
+                if field_value and not hasattr(BaseFactory, field_meta.name) and not isinstance(field_value, NeverNone):
                     if isinstance(field_value, Ignore):
                         continue
 

--- a/polyfactory/fields.py
+++ b/polyfactory/fields.py
@@ -22,6 +22,10 @@ class Require:
     """A factory field that marks an attribute as a required build-time kwarg."""
 
 
+class NeverNone:
+    """A factory field that marks as always generated, even if it's an optional"""
+
+
 class Ignore:
     """A factory field that marks an attribute as ignored."""
 


### PR DESCRIPTION
## Description
Right now, there is not an ergonomic way to mark a single field as "required" in the sense
that polyfactory should always generate a value for it, even if it's marked as optional.

Curious what you think about the approach, I still need to:

- [ ] write documentation
- [ ] write tests

## Closes

https://github.com/litestar-org/polyfactory/issues/655
