### PR TITLE
ci: add toml formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:
     hooks:
       - id: prettier
         exclude: ".all-contributorsrc"
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+        exclude: "uv.lock"
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.15.0"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ maintainers = [
   { name = "Jacob Coffee", email = "jacob@litestar.dev" },
   { name = "Peter Schutt", email = "peter@litestar.dev" },
   { name = "Alc", email = "alc@litestar.dev" },
+  { name = 'Andy', email = 'adh.truong@gmail.com' },
 ]
 keywords = ["dataclasses", "msgspec", "pydantic", "attrs", "sqlalchemy"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,62 +1,51 @@
 [project]
-authors = [
-    {name = "Na'aman Hirschfeld", email = "nhirschfeld@gmail.com"},
-]
+authors = [{ name = "Na'aman Hirschfeld", email = "nhirschfeld@gmail.com" }]
 maintainers = [
-    {name = "Visakh Unnikrishnan", email = "guacs@litestar.dev"},
-    {name = "Cody Fincher", email = "cody@litestar.dev"},
-    {name = "Janek Nouvertné", email = "janek@litestar.dev"},
-    {name = "Jacob Coffee", email = "jacob@litestar.dev"},
-    {name = "Peter Schutt", email = "peter@litestar.dev"},
-    {name = "Alc", email = "alc@litestar.dev"},
+  { name = "Visakh Unnikrishnan", email = "guacs@litestar.dev" },
+  { name = "Cody Fincher", email = "cody@litestar.dev" },
+  { name = "Janek Nouvertné", email = "janek@litestar.dev" },
+  { name = "Jacob Coffee", email = "jacob@litestar.dev" },
+  { name = "Peter Schutt", email = "peter@litestar.dev" },
+  { name = "Alc", email = "alc@litestar.dev" },
 ]
-keywords = ["dataclasses", "msgspec", "pydantic", "attrs", "sqlalchemy",]
+keywords = ["dataclasses", "msgspec", "pydantic", "attrs", "sqlalchemy"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Web Environment",
-    "Framework :: Pytest",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Natural Language :: English",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python",
-    "Topic :: Software Development :: Libraries",
-    "Topic :: Software Development :: Testing :: Unit",
-    "Topic :: Software Development :: Testing",
-    "Topic :: Software Development",
-    "Topic :: Utilities",
-    "Typing :: Typed",
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Web Environment",
+  "Framework :: Pytest",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Natural Language :: English",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Software Development :: Testing :: Unit",
+  "Topic :: Software Development :: Testing",
+  "Topic :: Software Development",
+  "Topic :: Utilities",
+  "Typing :: Typed",
 ]
 name = "polyfactory"
 version = "2.20.0"
 description = "Mock data generation factories"
 readme = "docs/PYPI_README.md"
-license = {text = "MIT"}
+license = { text = "MIT" }
 requires-python = ">=3.8,<4.0"
-dependencies = [
-    "faker>=5.0.0",
-    "typing-extensions>=4.6.0",
-]
+dependencies = ["faker>=5.0.0", "typing-extensions>=4.6.0"]
 
 [project.optional-dependencies]
-sqlalchemy = ["sqlalchemy>=1.4.29",]
-pydantic = [
-    "pydantic[email]>=1.10",
-]
-msgspec = ["msgspec",]
-odmantic = ["odmantic<1.0.0", "pydantic[email]",]
-beanie = [
-    "beanie",
-    "pydantic[email]",
-    "pymongo<4.9",
-]
-attrs = ["attrs>=22.2.0",]
+sqlalchemy = ["sqlalchemy>=1.4.29"]
+pydantic = ["pydantic[email]>=1.10"]
+msgspec = ["msgspec"]
+odmantic = ["odmantic<1.0.0", "pydantic[email]"]
+beanie = ["beanie", "pydantic[email]", "pymongo<4.9"]
+attrs = ["attrs>=22.2.0"]
 full = ["pydantic", "odmantic", "msgspec", "beanie", "attrs", "sqlalchemy"]
 
 [project.urls]
@@ -82,40 +71,40 @@ polyfactory = { workspace = true }
 
 [dependency-groups]
 docs = [
-    "sphinx>=7.1.2",
-    "sphinx-autobuild>=2021.3.14",
-    "auto-pytabs>=0.4.0",
-    "sphinx-copybutton>=0.5.2",
-    "sphinx-toolbox>=3.5.0",
-    "sphinx-design>=0.5.0",
-    "sphinxcontrib-mermaid>=0.9.2",
-    "sphinx-paramlinks>=0.6.0",
-    "sphinx-togglebutton>=0.3.2",
-    #    "litestar-sphinx-theme @ {root:uri}/../litestar-sphinx-theme", # only needed when working on the theme
-    "litestar-sphinx-theme @ git+https://github.com/litestar-org/litestar-sphinx-theme.git@v3",
-    "git-cliff>=2.2.1",
+  "sphinx>=7.1.2",
+  "sphinx-autobuild>=2021.3.14",
+  "auto-pytabs>=0.4.0",
+  "sphinx-copybutton>=0.5.2",
+  "sphinx-toolbox>=3.5.0",
+  "sphinx-design>=0.5.0",
+  "sphinxcontrib-mermaid>=0.9.2",
+  "sphinx-paramlinks>=0.6.0",
+  "sphinx-togglebutton>=0.3.2",
+  #    "litestar-sphinx-theme @ {root:uri}/../litestar-sphinx-theme", # only needed when working on the theme
+  "litestar-sphinx-theme @ git+https://github.com/litestar-org/litestar-sphinx-theme.git@v3",
+  "git-cliff>=2.2.1",
 ]
 lint = [
-    "ruff>=0.0.290",
-    "codespell>=2.2.5",
-    "mypy>=1.5.1",
-    "pre-commit>=3.4.0",
-    "shellcheck-py>=0.9.0.5",
-    "pyright>=1.1.327",
-    "sourcery>=1.9.0",
+  "ruff>=0.0.290",
+  "codespell>=2.2.5",
+  "mypy>=1.5.1",
+  "pre-commit>=3.4.0",
+  "shellcheck-py>=0.9.0.5",
+  "pyright>=1.1.327",
+  "sourcery>=1.9.0",
 ]
 test = [
-    "pytest>=7.4.2",
-    "pytest-asyncio>=0.21.1",
-    "pytest-cov>=4.1.0",
-    "hypothesis>=6.86.2",
-    "annotated-types>=0.5.0",
+  "pytest>=7.4.2",
+  "pytest-asyncio>=0.21.1",
+  "pytest-cov>=4.1.0",
+  "hypothesis>=6.86.2",
+  "annotated-types>=0.5.0",
 ]
 dev = [
-    "polyfactory[full]",
-    "mongomock-motor>=0.0.21",
-    "aiosqlite>=0.19.0",
-    "sqlalchemy[asyncio]>=1.4.29",
+  "polyfactory[full]",
+  "mongomock-motor>=0.0.21",
+  "aiosqlite>=0.19.0",
+  "sqlalchemy[asyncio]>=1.4.29",
 ]
 
 [tool.mypy]
@@ -153,24 +142,24 @@ omit = ["*/tests/*"]
 addopts = "--strict-config --strict-markers"
 asyncio_mode = "auto"
 filterwarnings = [
-    "ignore:.*pkg_resources.declare_namespace\\('sphinxcontrib'\\).*:DeprecationWarning",
-    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
-    # Get rid those above once sphinxcontrib-mermaid doesn't use pkg_resources anymore
-    # https://github.com/mgaitan/sphinxcontrib-mermaid/issues/119
+  "ignore:.*pkg_resources.declare_namespace\\('sphinxcontrib'\\).*:DeprecationWarning",
+  "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+  # Get rid those above once sphinxcontrib-mermaid doesn't use pkg_resources anymore
+  # https://github.com/mgaitan/sphinxcontrib-mermaid/issues/119
 ]
 markers = [
-    # Marks tests that use `attrs` library
-    "attrs",
+  # Marks tests that use `attrs` library
+  "attrs",
 ]
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.report]
 exclude_lines = [
-    'pragma: no cover',
-    'if TYPE_CHECKING:',
-    'except ImportError:',
-    'except ImportError as e:',
-    '\.\.\.',
+  'pragma: no cover',
+  'if TYPE_CHECKING:',
+  'except ImportError:',
+  'except ImportError as e:',
+  '\.\.\.',
 ]
 
 [tool.ruff]
@@ -185,25 +174,25 @@ docstring-code-line-length = 88
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-    "A003",  # flake8-builtins - class attribute {name} is shadowing a python builtin
-    "B010",  # flake8-bugbear - do not call setattr with a constant attribute value
-    "D100",  # pydocstyle - missing docstring in public module
-    "D101",  # pydocstyle - missing docstring in public class
-    "D102",  # pydocstyle - missing docstring in public method
-    "D103",  # pydocstyle - missing docstring in public function
-    "D104",  # pydocstyle - missing docstring in public package
-    "D105",  # pydocstyle - missing docstring in magic method
-    "D106",  # pydocstyle - missing docstring in public nested class
-    "D107",  # pydocstyle - missing docstring in __init__
-    "D202",  # pydocstyle - no blank lines allowed after function docstring
-    "D205",  # pydocstyle - 1 blank line required between summary line and description
-    "D415",  # pydocstyle - first line should end with a period, question mark, or exclamation point
-    "E501",  # pycodestyle line too long, handled by black
-    "N818",  # pep8-naming - exception name should be named with an Error suffix
-    "S311",  # flake8-bandit - Standard pseudo-random generators are not suitable for security/cryptographic purposes
-    "UP037", # pyupgrade - removes quotes from type annotation
-    "COM812",  # conflict with formatter
-    "ISC001",  # conflict with formatter
+  "A003",   # flake8-builtins - class attribute {name} is shadowing a python builtin
+  "B010",   # flake8-bugbear - do not call setattr with a constant attribute value
+  "D100",   # pydocstyle - missing docstring in public module
+  "D101",   # pydocstyle - missing docstring in public class
+  "D102",   # pydocstyle - missing docstring in public method
+  "D103",   # pydocstyle - missing docstring in public function
+  "D104",   # pydocstyle - missing docstring in public package
+  "D105",   # pydocstyle - missing docstring in magic method
+  "D106",   # pydocstyle - missing docstring in public nested class
+  "D107",   # pydocstyle - missing docstring in __init__
+  "D202",   # pydocstyle - no blank lines allowed after function docstring
+  "D205",   # pydocstyle - 1 blank line required between summary line and description
+  "D415",   # pydocstyle - first line should end with a period, question mark, or exclamation point
+  "E501",   # pycodestyle line too long, handled by black
+  "N818",   # pep8-naming - exception name should be named with an Error suffix
+  "S311",   # flake8-bandit - Standard pseudo-random generators are not suitable for security/cryptographic purposes
+  "UP037",  # pyupgrade - removes quotes from type annotation
+  "COM812", # conflict with formatter
+  "ISC001", # conflict with formatter
 ]
 
 [tool.ruff.lint.flake8-builtins]
@@ -214,109 +203,118 @@ convention = "google"
 
 [tool.ruff.lint.pep8-naming]
 classmethod-decorators = [
-    "classmethod",
-    "pydantic.validator",
-    "pydantic.root_validator",
-    "sqlalchemy.ext.declarative.declared_attr",
+  "classmethod",
+  "pydantic.validator",
+  "pydantic.root_validator",
+  "sqlalchemy.ext.declarative.declared_attr",
 ]
 
 [tool.ruff.lint.isort]
 known-first-party = ["polyfactory", "tests"]
-section-order = ["future", "standard-library", "third-party", "pydantic", "pydantic_v1", "first-party", "local-folder"]
+section-order = [
+  "future",
+  "standard-library",
+  "third-party",
+  "pydantic",
+  "pydantic_v1",
+  "first-party",
+  "local-folder",
+]
 
 [tool.ruff.lint.isort.sections]
 pydantic = ["pydantic", "pydantic_core"]
 pydantic_v1 = ["pydantic.v1"]
 
 [tool.ruff.lint.per-file-ignores]
-"**/*.*" = ["ANN101", "ANN401", "ANN102", "TD",]
-"polyfactory/**/*.*" = ["PLR0913",
-    "ARG005", # Investigate @guacs
-    "FBT001", # Investigate @guacs
-    "FBT002", # Investigate @guacs
-    "SLF001", # Ignore use of private member access
-    ]
+"**/*.*" = ["ANN401", "TD"]
+"polyfactory/**/*.*" = [
+  "PLR0913",
+  "ARG005",  # Investigate @guacs
+  "FBT001",  # Investigate @guacs
+  "FBT002",  # Investigate @guacs
+  "SLF001",  # Ignore use of private member access
+]
 "polyfactory/field_meta.py" = ["N806"]
 "tests/**/*.*" = [
-    "S101",
-    "D",
-    "ARG",
-    "PGH",
-    "B",
-    "FBT",
-    "PTH",
-    "A",
-    "TCH",
-    "DTZ",
-    "TRY",
-    "EM",
-    "S",
-    "N",
-    "SIM",
-    "PLR",
-    "BLE",
-    "RSE",
-    "C901",
-    "PLW",
-    "G",
-    "PIE",
-    "RUF012",
-    "FA",
-    "ANN",
-    "SLF",
-    "PT",
-    "INP",
-    "TD",
-    "FIX",
-    "FBT",
-    "PLR0913", # too many arguments
-    "PT",
-    "ARG002", # Investigate @guacs
-    "PERF203", # Investigate @guacs
+  "S101",
+  "D",
+  "ARG",
+  "PGH",
+  "B",
+  "FBT",
+  "PTH",
+  "A",
+  "TC",
+  "DTZ",
+  "TRY",
+  "EM",
+  "S",
+  "N",
+  "SIM",
+  "PLR",
+  "BLE",
+  "RSE",
+  "C901",
+  "PLW",
+  "G",
+  "PIE",
+  "RUF012",
+  "FA",
+  "ANN",
+  "SLF",
+  "PT",
+  "INP",
+  "TD",
+  "FIX",
+  "FBT",
+  "PLR0913", # too many arguments
+  "PT",
+  "ARG002",  # Investigate @guacs
+  "PERF203", # Investigate @guacs
 ]
 "docs/examples/**/*.*" = [
-    "PLR2004", # Investigate @guacs
-    "INP001", # Add __init__.py
-    ]
+  "PLR2004", # Investigate @guacs
+  "INP001",  # Add __init__.py
+]
 "docs/examples/tests/**/*.*" = [
-    "S101",
-    "D",
-    "ARG",
-    "PGH",
-    "B",
-    "FBT",
-    "PTH",
-    "A",
-    "TCH",
-    "DTZ",
-    "TRY",
-    "EM",
-    "S",
-    "N",
-    "SIM",
-    "PLR",
-    "BLE",
-    "RSE",
-    "C901",
-    "PLW",
-    "G",
-    "PIE",
+  "S101",
+  "D",
+  "ARG",
+  "PGH",
+  "B",
+  "FBT",
+  "PTH",
+  "A",
+  "TC",
+  "DTZ",
+  "TRY",
+  "EM",
+  "S",
+  "N",
+  "SIM",
+  "PLR",
+  "BLE",
+  "RSE",
+  "C901",
+  "PLW",
+  "G",
+  "PIE",
 ]
 "docs/**/*.*" = [
-    "S",
-    "B",
-    "DTZ",
-    "A",
-    "TCH",
-    "ERA",
-    "D",
-    "RET",
-    "E731",
-    "RUF012",
-    "FA100",
-    "ARG001",
+  "S",
+  "B",
+  "DTZ",
+  "A",
+  "TC",
+  "ERA",
+  "D",
+  "RET",
+  "E731",
+  "RUF012",
+  "FA100",
+  "ARG001",
 ]
-"docs/conf.py" = ["FIX002", "ARG001",]
+"docs/conf.py" = ["FIX002", "ARG001"]
 "tools/**/*.*" = ["D", "ARG", "EM", "TRY", "G", "FBT", "INP"]
 
 [tool.git-cliff.changelog]
@@ -388,20 +386,20 @@ split_commits = false
 tag_pattern = "v[0-9]*"
 topo_order = false
 commit_preprocessors = [
-    # Matches a single backtick that is not preceded by another backtick (negative lookbehind)
-    # and not followed by another backtick (negative lookahead).. but these aren't supported
-    # in git cliff regexes. So we have to do it in 3 steps:
-    # Step 1: Replace pairs of backticks with a placeholder (e.g., "DOUBLEBACKTICK")
-    { pattern = "``", replace = "DOUBLEBACKTICK" },
-    # Step 2: Replace single backticks with double backticks
-    { pattern = "`", replace = "``" },
-    # Step 3: Replace the placeholder back to double backticks
-    { pattern = "DOUBLEBACKTICK", replace = "``" },
-    # TODO: Fix Co-authored commits
+  # Matches a single backtick that is not preceded by another backtick (negative lookbehind)
+  # and not followed by another backtick (negative lookahead).. but these aren't supported
+  # in git cliff regexes. So we have to do it in 3 steps:
+  # Step 1: Replace pairs of backticks with a placeholder (e.g., "DOUBLEBACKTICK")
+  { pattern = "``", replace = "DOUBLEBACKTICK" },
+  # Step 2: Replace single backticks with double backticks
+  { pattern = "`", replace = "``" },
+  # Step 3: Replace the placeholder back to double backticks
+  { pattern = "DOUBLEBACKTICK", replace = "``" },
+  # TODO: Fix Co-authored commits
 ]
 link_parsers = [
-    # TODO: Supposedly matches on #1234 but doesn't work?
-    { pattern = "\\(#(\\d+)\\)", href = "https://github.com/litestar-org/polyfactory/issues/$1" },
+  # TODO: Supposedly matches on #1234 but doesn't work?
+  { pattern = "\\(#(\\d+)\\)", href = "https://github.com/litestar-org/polyfactory/issues/$1" },
 ]
 
 [tool.git-cliff.remote.github]


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- add toml formatter. Causing annoyances when working locally with format on save configured
- note this works well with uv add 
- also update old ruff rules. ANN101 and ANN104 are removed. TCH renamed to TC

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
