### PR TITLE
fix: handle pydantic v1 URL and email correctly

### DIFF
--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -296,12 +296,17 @@ class PydanticFieldMeta(FieldMeta):
         # pydantic v1 has constraints set for these values, but we generate them using faker
         if unwrap_optional(annotation) in (
             AnyUrl,
+            AnyHttpUrl,
             HttpUrl,
+            pydantic_v1.AnyUrl,
+            pydantic_v1.AnyHttpUrl,
+            pydantic_v1.HttpUrl,
             pydantic_v1.KafkaDsn,
             pydantic_v1.PostgresDsn,
             pydantic_v1.RedisDsn,
             pydantic_v1.AmqpDsn,
-            AnyHttpUrl,
+            pydantic_v1.EmailStr,
+            pydantic_v1.NameEmail,
         ):
             constraints = {}
 
@@ -567,6 +572,9 @@ class ModelFactory(Generic[T], BaseFactory[T]):
         # v1 only values
         mapping.update(
             {
+                pydantic_v1.AnyUrl: cls.__faker__.url,
+                pydantic_v1.AnyHttpUrl: cls.__faker__.url,
+                pydantic_v1.HttpUrl: cls.__faker__.url,
                 pydantic_v1.PyObject: lambda: "decimal.Decimal",
                 pydantic_v1.AmqpDsn: lambda: "amqps://example.com",
                 pydantic_v1.KafkaDsn: lambda: "kafka://localhost:9092",
@@ -579,6 +587,8 @@ class ModelFactory(Generic[T], BaseFactory[T]):
                 pydantic_v1.UUID4: cls.__faker__.uuid4,
                 pydantic_v1.UUID5: lambda: uuid5(NAMESPACE_DNS, cls.__faker__.pystr()),
                 Color: cls.__faker__.hex_color,  # pyright: ignore[reportGeneralTypeIssues]
+                pydantic_v1.EmailStr: cls.__faker__.free_email,
+                pydantic_v1.NameEmail: cls.__faker__.free_email,
             },
         )
 

--- a/tests/test_pydantic_v1_v2.py
+++ b/tests/test_pydantic_v1_v2.py
@@ -90,3 +90,17 @@ def test_variadic_tuple_length() -> None:
 
     result = Factory.build()
     assert 7 <= len(result.bar) <= 8
+
+
+def test_build_v1_with_url_and_email_types() -> None:
+    from pydantic.v1 import AnyHttpUrl, AnyUrl, EmailStr, HttpUrl, NameEmail
+
+    class Foo(BaseModelV1):
+        http_url: HttpUrl
+        any_http_url: AnyHttpUrl
+        any_url: AnyUrl
+        email_str: EmailStr
+        name_email: NameEmail
+        composed: Tuple[HttpUrl, AnyHttpUrl, AnyUrl, EmailStr, NameEmail]
+
+    ModelFactory.create_factory(Foo).build()


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

When using a Pydantic v1 model in a mixed v1/v2 environment (legacy code, you know), `polyfactory` does not handle `pydantic.v1.HttpUrl` and `pydantic.v1.EmailStr` correctly, and treats them as regular `str`.

This PR fixes the error that occurs when running the code below.

```python
from pydantic.v1 import BaseModel, EmailStr, HttpUrl

from polyfactory.factories.pydantic_factory import ModelFactory


class Foobar(BaseModel):
    url: HttpUrl
    email: EmailStr


class FoobarFactory(ModelFactory[Foobar]): ...


def main():
    factory = FoobarFactory()
    print(factory.build())
    # pydantic.v1.error_wrappers.ValidationError: 2 validation errors for Foobar
    # url
    #   invalid or missing URL scheme (type=value_error.url.scheme)
    # email
    #   value is not a valid email address (type=value_error.email)


if __name__ == "__main__":
    main()
```
