### PR TITLE
feat: Allow usage of Pydantic models containing forward references

### DIFF
--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -396,13 +396,16 @@ class ModelFactory(Generic[T], BaseFactory[T]):
     def __init_subclass__(cls, *args: Any, **kwargs: Any) -> None:
         super().__init_subclass__(*args, **kwargs)
 
-        if (
-            getattr(cls, "__model__", None)
-            and _is_pydantic_v1_model(cls.__model__)
-            and hasattr(cls.__model__, "update_forward_refs")
-        ):
+        model = getattr(cls, "__model__", None)
+        if model is None:
+            return
+
+        if _is_pydantic_v1_model(model) and hasattr(cls.__model__, "update_forward_refs"):
             with suppress(NameError):  # pragma: no cover
-                cls.__model__.update_forward_refs(**cls.__forward_ref_resolution_type_mapping__)  # type: ignore[attr-defined]
+                cls.__model__.update_forward_refs(**cls.__forward_ref_resolution_type_mapping__)
+
+        if _is_pydantic_v2_model(model):
+            model.model_rebuild()
 
     @classmethod
     def is_supported_type(cls, value: Any) -> TypeGuard[type[T]]:

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -1100,3 +1100,18 @@ def test_use_examples_value_override() -> None:
 
     instance = PaymentFactory.build(currency="DKK")
     assert instance.currency == "DKK"
+
+
+class Base(BaseModel):
+    nested: "Nested"
+
+
+class Nested(BaseModel):
+    value: int
+
+
+def test_rebuild() -> None:
+    class BaseFactory(ModelFactory[Base]):
+        pass
+
+    assert isinstance(BaseFactory.build(), Base)


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Call `model_rebuild` when instantiating a `ModelFactory` so that forward references may be replaced with concrete field information (the equivalent is already done for Pydantic V1).

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Fixes https://github.com/litestar-org/polyfactory/issues/686.