### PR TITLE
fix: Pydantic Factory alias generation from version 2.11

### DIFF
--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -459,14 +459,14 @@ class ModelFactory(Generic[T], BaseFactory[T]):
                     for field in cls.__model__.__fields__.values()
                 ]
             else:
+                use_alias = cls.__model__.model_config.get("validate_by_name", False) or cls.__model__.model_config.get(
+                    "populate_by_name", False
+                )
                 cls._fields_metadata = [
                     PydanticFieldMeta.from_field_info(
                         field_info=field_info,
                         field_name=field_name,
-                        use_alias=not cls.__model__.model_config.get(  # pyright: ignore[reportGeneralTypeIssues]
-                            "populate_by_name",
-                            False,
-                        ),
+                        use_alias=not use_alias,
                     )
                     for field_name, field_info in cls.__model__.model_fields.items()  # pyright: ignore[reportGeneralTypeIssues]
                 ]


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- This PR aims to fix alias generation. This is due to `populate_by_name` config attribute being deprecated by Pydantic from version 2.11

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Closes #717 
