### PR TITLE
fix: handle recursive types that use ForwardRef

### DIFF
--- a/docs/examples/configuration/test_example_11.py
+++ b/docs/examples/configuration/test_example_11.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Union
+
+from polyfactory.factories import DataclassFactory
+
+# Define a recursive type using forward reference
+RecursiveType = Union[List["RecursiveType"], int]
+
+
+@dataclass
+class RecursiveTypeModel:
+    recursive_value: RecursiveType
+
+
+class RecursiveTypeModelFactory(DataclassFactory[RecursiveTypeModel]):
+    __forward_references__ = {"RecursiveType": int}
+
+
+def test_forward_references() -> None:
+    factory = RecursiveTypeModelFactory()
+    result = factory.build().recursive_value
+    assert isinstance(result, int) or (isinstance(result, list) and all(isinstance(value, int) for value in result))

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -146,3 +146,21 @@ By default, ``__use_examples__`` is set to ``False.``
 .. literalinclude:: /examples/configuration/test_example_10.py
     :caption: Use Examples Values
     :language: python
+
+
+Forward References
+------------------
+
+The ``__forward_references__`` configuration allows you to resolve forward references in type annotations.
+This is useful when dealing with recursive types that cannot be resolved automatically.
+
+By default, ``__forward_references__`` is set to an empty dictionary. You can provide a mapping of
+forward reference names to their resolved types.
+
+.. literalinclude:: /examples/configuration/test_example_11.py
+    :caption: Forward References Configuration
+    :language: python
+
+.. note::
+    The Pydantic ModelFactory has a default forward reference mapping for ``JsonValue`` to resolve to ``str``
+    to avoid recursive issues with Pydantic's JsonValue type.

--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -404,6 +404,11 @@ class ModelFactory(Generic[T], BaseFactory[T]):
     >>> payment
     Payment(amount=120, currency="EUR")
     """
+    if not _IS_PYDANTIC_V1:
+        __forward_references__: ClassVar[dict[str, Any]] = {
+            # Resolve to str to avoid recursive issues
+            "JsonValue": str,
+        }
 
     __config_keys__ = (
         *BaseFactory.__config_keys__,

--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -12,11 +12,10 @@ from polyfactory.utils.helpers import (
     get_annotation_metadata,
     is_dataclass_instance,
     unwrap_annotated,
-    unwrap_forward_ref,
     unwrap_new_type,
 )
 from polyfactory.utils.normalize_type import normalize_type
-from polyfactory.utils.predicates import is_annotated, is_forward_ref
+from polyfactory.utils.predicates import is_annotated
 from polyfactory.utils.types import NoneType
 
 if TYPE_CHECKING:
@@ -145,9 +144,6 @@ class FieldMeta:
                 ("random", random),
             ),
         )
-
-        if is_forward_ref(annotation):
-            annotation = unwrap_forward_ref(annotation)
 
         annotation = normalize_type(annotation)
         annotated = is_annotated(annotation)

--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -8,9 +8,15 @@ from typing_extensions import get_args, get_origin
 
 from polyfactory.constants import DEFAULT_RANDOM, TYPE_MAPPING
 from polyfactory.utils.deprecation import check_for_deprecated_parameters
-from polyfactory.utils.helpers import get_annotation_metadata, is_dataclass_instance, unwrap_annotated, unwrap_new_type
+from polyfactory.utils.helpers import (
+    get_annotation_metadata,
+    is_dataclass_instance,
+    unwrap_annotated,
+    unwrap_forward_ref,
+    unwrap_new_type,
+)
 from polyfactory.utils.normalize_type import normalize_type
-from polyfactory.utils.predicates import is_annotated
+from polyfactory.utils.predicates import is_annotated, is_forward_ref
 from polyfactory.utils.types import NoneType
 
 if TYPE_CHECKING:
@@ -139,6 +145,9 @@ class FieldMeta:
                 ("random", random),
             ),
         )
+
+        if is_forward_ref(annotation):
+            annotation = unwrap_forward_ref(annotation)
 
         annotation = normalize_type(annotation)
         annotated = is_annotated(annotation)

--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -85,22 +85,6 @@ def unwrap_annotation(annotation: Any, random: Random | None = None) -> Any:
     return annotation
 
 
-def unwrap_forward_ref(annotation: Any) -> Any:
-    """Unwrap a ForwardRef.
-
-    :param annotation: A type annotation.
-
-    :returns: The unwrapped annotation.
-    """
-
-    try:
-        annotation = annotation._evaluate(globals(), locals(), set(), recursive_guard=set())
-    except (NameError, AttributeError, TypeError):
-        annotation = Any
-
-    return annotation
-
-
 def flatten_annotation(annotation: Any) -> list[Any]:
     """Flattens an annotation into an array of possible types. For example:
 

--- a/polyfactory/utils/helpers.py
+++ b/polyfactory/utils/helpers.py
@@ -85,6 +85,22 @@ def unwrap_annotation(annotation: Any, random: Random | None = None) -> Any:
     return annotation
 
 
+def unwrap_forward_ref(annotation: Any) -> Any:
+    """Unwrap a ForwardRef.
+
+    :param annotation: A type annotation.
+
+    :returns: The unwrapped annotation.
+    """
+
+    try:
+        annotation = annotation._evaluate(globals(), locals(), set(), recursive_guard=set())
+    except (NameError, AttributeError, TypeError):
+        annotation = Any
+
+    return annotation
+
+
 def flatten_annotation(annotation: Any) -> list[Any]:
     """Flattens an annotation into an array of possible types. For example:
 

--- a/polyfactory/utils/predicates.py
+++ b/polyfactory/utils/predicates.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from inspect import isclass
-from typing import Any, Literal, NewType, Optional, TypeVar, get_args
+from typing import Any, ForwardRef, Literal, NewType, Optional, TypeVar, get_args
 
 from typing_extensions import (
     Annotated,
@@ -180,3 +180,13 @@ def get_type_origin(annotation: Any) -> Any:
     if origin in (Annotated, Required, NotRequired):
         origin = get_args(annotation)[0]
     return mapped_type if (mapped_type := TYPE_MAPPING.get(origin)) else origin
+
+
+def is_forward_ref(annotation: Any) -> bool:
+    """Determine if the given type annotation is a ForwardRef.
+
+    :param annotation: A type annotation.
+
+    :returns: A boolean.
+    """
+    return isinstance(annotation, ForwardRef)

--- a/polyfactory/utils/predicates.py
+++ b/polyfactory/utils/predicates.py
@@ -182,7 +182,7 @@ def get_type_origin(annotation: Any) -> Any:
     return mapped_type if (mapped_type := TYPE_MAPPING.get(origin)) else origin
 
 
-def is_forward_ref(annotation: Any) -> bool:
+def is_forward_ref(annotation: Any) -> TypeGuard[ForwardRef]:
     """Determine if the given type annotation is a ForwardRef.
 
     :param annotation: A type annotation.

--- a/tests/test_recursive_models.py
+++ b/tests/test_recursive_models.py
@@ -107,7 +107,7 @@ def test_recursive_type_annotation() -> None:
     assert _get_types(result.json_value for result in factory.coverage()) == valid_types
 
 
-RecursiveType = list["RecursiveType"] | int
+RecursiveType = Union[List["RecursiveType"], int]
 
 
 def test_recursive_model_with_forward_ref() -> None:

--- a/tests/test_recursive_models.py
+++ b/tests/test_recursive_models.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, Iterable, List, Optional, TypeVar, Union
 
 import pytest
 
-from pydantic import BaseModel, Field, JsonValue
+from pydantic import BaseModel, Field
+from pydantic import __version__ as pydantic_version
 
 from polyfactory.factories.dataclass_factory import DataclassFactory
 from polyfactory.factories.pydantic_factory import ModelFactory
@@ -90,7 +91,10 @@ def test_recursive_list_model() -> None:
     assert book_factory.build(author=None).author is None
 
 
+@pytest.mark.skipif(pydantic_version.startswith("1"), reason="Pydantic v2+ is required for JsonValue")
 def test_recursive_type_annotation() -> None:
+    from pydantic import JsonValue
+
     class RecursiveTypeModel(BaseModel):
         json_value: JsonValue
 

--- a/tests/test_recursive_models.py
+++ b/tests/test_recursive_models.py
@@ -115,7 +115,10 @@ def test_recursive_model_with_forward_ref() -> None:
     class RecursiveTypeModel:
         json_value: RecursiveType
 
-    factory = DataclassFactory.create_factory(RecursiveTypeModel)
+    factory = DataclassFactory.create_factory(
+        RecursiveTypeModel,
+        __forward_references__={"RecursiveType": int},
+    )
     results = factory.batch(50)
 
     valid_types = {int, list}

--- a/tests/test_type_coverage_generation.py
+++ b/tests/test_type_coverage_generation.py
@@ -228,7 +228,7 @@ def test_coverage_optional_field() -> None:
         __model__ = OptionalInt
 
     results = list(OptionalIntFactory.coverage())
-    assert len(results) == 2
+    assert len(results) == 2, results
 
     assert isinstance(results[0].i, int)
     assert results[1].i is None


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Handling of union and recursive types changed slightly with https://github.com/litestar-org/polyfactory/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aclosed
- Update to handle forward ref explicitly

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Closes #725 