### PR TITLE
fix: allow specifying forward references when as string

### DIFF
--- a/polyfactory/factories/beanie_odm_factory.py
+++ b/polyfactory/factories/beanie_odm_factory.py
@@ -29,7 +29,7 @@ class BeaniePersistenceHandler(Generic[T], AsyncPersistenceProtocol[T]):
 
     async def save(self, data: T) -> T:
         """Persist a single instance in mongoDB."""
-        return await data.insert()  # pyright: ignore[reportGeneralTypeIssues]
+        return await data.insert()  # type: ignore[no-any-return]
 
     async def save_many(self, data: list[T]) -> list[T]:
         """Persist multiple instances in mongoDB.

--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -95,6 +95,10 @@ class FieldMeta:
         self.name = name
         self.constraints = constraints
 
+    def __repr__(self) -> str:
+        """Return a string representation of the field meta."""
+        return f"FieldMeta(name={self.name!r}, annotation={self.annotation!r}, default={self.default!r}, children={self.children!r}, constraints={self.constraints!r})"
+
     @functools.cached_property
     def type_args(self) -> tuple[Any, ...]:
         """Return the normalized type args of the annotation, if any.

--- a/tests/test_recursive_models.py
+++ b/tests/test_recursive_models.py
@@ -20,7 +20,7 @@ class Node:
     value: int
     union_child: Union[Node, int]  # noqa: UP007
     list_child: List[Node]  # noqa: UP006
-    optional_child: Optional[Node]  # noqa: UP007
+    optional_child: Optional[Node]  # noqa: RUF100, UP007, UP045
     child: Node = field(default=_Sentinel)  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
@@ -46,7 +46,7 @@ class PydanticNode(BaseModel):
     union_child: Union[PydanticNode, int]  # noqa: UP007
     list_child: List[PydanticNode]  # noqa: UP006
     optional_union_child: Union[PydanticNode, None]  # noqa: UP007
-    optional_child: Optional[PydanticNode]  # noqa: UP007
+    optional_child: Optional[PydanticNode]  # noqa: RUF100, UP007, UP045
     child: PydanticNode = Field(default=_Sentinel)  # type: ignore[assignment]
     recursive_key: Dict[PydanticNode, Any]  # noqa: UP006
     recursive_value: Dict[str, PydanticNode]  # noqa: UP006


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Fix handling in some case for Pydantic where things resolve to string rather than forward refs. 
- Note this is slightly hard to test via ci as requiring dropping 3.8 to show breakage on newest pydantic version
- Running locally this works where failed previously on main

<img width="811" height="570" alt="image" src="https://github.com/user-attachments/assets/8df48feb-bb05-4f63-a8d9-d1593d56e5d1" />


<img width="763" height="458" alt="image" src="https://github.com/user-attachments/assets/335aaaca-9336-4a2a-9e00-88024113855c" />


<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Closes https://github.com/litestar-org/polyfactory/issues/733
