### PR TITLE
fix: pydantic alias handling

### DIFF
--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -169,7 +169,9 @@ class PydanticFieldMeta(FieldMeta):
             ),
         )
         field_info = FieldInfo.merge_field_infos(
-            field_info, FieldInfo.from_annotation(normalize_type(field_info.annotation))
+            field_info,
+            FieldInfo.from_annotation(normalize_type(field_info.annotation)),
+            alias=field_info.alias,
         )
 
         if callable(field_info.default_factory):

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -26,6 +26,7 @@ from pydantic import (
     AnyUrl,
     BaseModel,
     ByteSize,
+    ConfigDict,
     DirectoryPath,
     EmailStr,
     Field,
@@ -1456,3 +1457,20 @@ def test_pep695_dict_union_types(create_module: Callable[[str], ModuleType]) -> 
         """)
     )
     ModelFactory.create_factory(module.Foo).build()
+
+
+def test_alias_overrides() -> None:
+    """Test that type aliases can be overridden."""
+
+    class Foo(BaseModel):
+        model_config = ConfigDict(alias_generator=lambda x: x.upper())
+
+        name: str  # type: ignore[pydantic-alias]
+
+    class FooFactory(ModelFactory[Foo]):
+        __check_model__ = True
+
+        NAME = "John"
+
+    instance = FooFactory.build()
+    assert instance.name == "John"  # Should use the overridden alias

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -1459,6 +1459,7 @@ def test_pep695_dict_union_types(create_module: Callable[[str], ModuleType]) -> 
     ModelFactory.create_factory(module.Foo).build()
 
 
+@pytest.mark.skipif(IS_PYDANTIC_V1, reason="pydantic 2 only test")
 def test_alias_overrides() -> None:
     """Test that type aliases can be overridden."""
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- Fix alias handling for 2.22
- This is regression from [normalisation introduced here](https://github.com/litestar-org/polyfactory/commit/c7a7b4426126d0134d531fc4db34199d39c46298) that meant alias is not propagated. 
- This is slightly hack to focus this but fine before can cleanup this logic with https://github.com/litestar-org/polyfactory/issues/713

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes

Closes https://github.com/litestar-org/polyfactory/issues/736
