### PR TITLE
fix: remove association proxy default change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,6 @@ markers = [
   "attrs",
 ]
 asyncio_default_fixture_loop_scope = "function"
-testpaths = ["tests", "docs/examples"]
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

- This reverts the change proposed for v3 of changing this default 
- This is done because association proxy will often be declared with relationships so will be redundant to calculate twice

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
