### PR TITLE
fix(msgspec): handle boolean tz constraint from Meta

### DIFF
--- a/polyfactory/value_generators/constrained_dates.py
+++ b/polyfactory/value_generators/constrained_dates.py
@@ -13,7 +13,7 @@ def handle_constrained_date(
     gt: date | None = None,
     le: date | None = None,
     lt: date | None = None,
-    tz: tzinfo = timezone.utc,
+    tz: tzinfo | bool | None = timezone.utc,
 ) -> date:
     """Generates a date value fulfilling the expected constraints.
 
@@ -22,10 +22,16 @@ def handle_constrained_date(
     :param le: Less than or equal value.
     :param gt: Greater than value.
     :param ge: Greater than or equal value.
-    :param tz: A timezone.
+    :param tz: A timezone. If a bool is passed (e.g. from msgspec Meta(tz=True)),
+        True is converted to UTC and False to None.
 
     :returns: A date instance.
     """
+    # Handle boolean tz values from msgspec's Meta constraint
+    if isinstance(tz, bool):
+        tz = timezone.utc if tz else None
+    elif tz is None:
+        tz = timezone.utc
     start_date = datetime.now(tz=tz).date() - timedelta(days=100)
     if ge:
         start_date = ge


### PR DESCRIPTION
## Problem

When using `msgspec.Meta(tz=True)` with a datetime field, polyfactory crashes with a `TypeError` because `handle_constrained_date` receives a `bool` for the `tz` parameter but expects a `tzinfo` object.

Closes #768

### Reproduction

```python
from datetime import datetime
from typing import Annotated

from msgspec import Struct, Meta
from polyfactory.factories.msgspec_factory import MsgspecFactory


class SomeStruct(Struct):
    some_datetime: Annotated[datetime, Meta(tz=True)]


class SomeStructFactory(MsgspecFactory[SomeStruct]): ...

SomeStructFactory.build()  # TypeError!
```

## Solution

In `handle_constrained_date`, convert boolean `tz` values before using them:
- `True` → `timezone.utc` (timezone-aware datetime)
- `False` → `None` (falls back to UTC default)

This is a minimal, targeted fix in `polyfactory/value_generators/constrained_dates.py`.

## Changes

| File | Change |
|------|--------|
| `polyfactory/value_generators/constrained_dates.py` | Update `tz` type hint to accept `bool`, convert boolean values before use |