### PR TITLE
fix: return datetime instead of date for constrained datetime fields

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -74,7 +74,7 @@ from polyfactory.value_generators.constrained_collections import (
     handle_constrained_collection,
     handle_constrained_mapping,
 )
-from polyfactory.value_generators.constrained_dates import handle_constrained_date
+from polyfactory.value_generators.constrained_dates import handle_constrained_date, handle_constrained_datetime
 from polyfactory.value_generators.constrained_numbers import (
     handle_constrained_decimal,
     handle_constrained_float,
@@ -704,6 +704,16 @@ class BaseFactory(ABC, Generic[T]):
                     unique_items=constraints.get("unique_items", False),
                     field_build_parameters=field_build_parameters,
                     build_context=build_context,
+                )
+
+            if is_safe_subclass(annotation, datetime):
+                return handle_constrained_datetime(
+                    faker=cls.__faker__,
+                    ge=cast("Any", constraints.get("ge")),
+                    gt=cast("Any", constraints.get("gt")),
+                    le=cast("Any", constraints.get("le")),
+                    lt=cast("Any", constraints.get("lt")),
+                    tz=cast("Any", constraints.get("tz")),
                 )
 
             if is_safe_subclass(annotation, date):

--- a/polyfactory/value_generators/constrained_dates.py
+++ b/polyfactory/value_generators/constrained_dates.py
@@ -39,3 +39,51 @@ def handle_constrained_date(
         end_date = lt - timedelta(days=1)
 
     return faker.date_between(start_date=start_date, end_date=end_date)
+
+
+def handle_constrained_datetime(
+    faker: Faker,
+    ge: date | datetime | None = None,
+    gt: date | datetime | None = None,
+    le: date | datetime | None = None,
+    lt: date | datetime | None = None,
+    tz: tzinfo | bool | None = timezone.utc,
+) -> datetime:
+    """Generates a datetime value fulfilling the expected constraints.
+
+    :param faker: An instance of faker.
+    :param lt: Less than value.
+    :param le: Less than or equal value.
+    :param gt: Greater than value.
+    :param ge: Greater than or equal value.
+    :param tz: A timezone. If a bool is passed (e.g. from msgspec Meta(tz=True)),
+        True is converted to UTC and False to None.
+
+    :returns: A datetime instance.
+    """
+    # Handle boolean tz values from msgspec's Meta constraint
+    if isinstance(tz, bool):
+        tz = timezone.utc if tz else None
+    elif tz is None:
+        tz = timezone.utc
+
+    start_date = datetime.now(tz=tz) - timedelta(days=100)
+    if ge:
+        start_date = ge if isinstance(ge, datetime) else datetime.combine(ge, datetime.min.time(), tzinfo=tz)
+    elif gt:
+        if isinstance(gt, datetime):
+            start_date = gt + timedelta(seconds=1)
+        else:
+            start_date = datetime.combine(gt + timedelta(days=1), datetime.min.time(), tzinfo=tz)
+
+    end_date = datetime.now(tz=tz) + timedelta(days=100)
+    if le:
+        end_date = le if isinstance(le, datetime) else datetime.combine(le, datetime.max.time(), tzinfo=tz)
+    elif lt:
+        if isinstance(lt, datetime):
+            end_date = lt - timedelta(seconds=1)
+        else:
+            end_date = datetime.combine(lt - timedelta(days=1), datetime.max.time(), tzinfo=tz)
+
+    result = faker.date_time_between(start_date=start_date, end_date=end_date, tzinfo=tz)
+    return result


### PR DESCRIPTION
## Problem

When a pydantic model has a constrained `datetime` field (e.g. with `gt`/`lt` bounds or a `BeforeValidator`), polyfactory generates a `date` object instead of a `datetime`. This causes `AttributeError` when validators try to access `.tzinfo`.

Closes #734

### Reproduction

```python
from typing import Annotated
import datetime
from pydantic import BaseModel, Field, BeforeValidator
from polyfactory.factories.pydantic_factory import ModelFactory

def validate_datetime(value: datetime.datetime) -> datetime.datetime:
    assert value.tzinfo == datetime.timezone.utc  # AttributeError!
    return value

ValidatedDatetime = Annotated[datetime.datetime, BeforeValidator(validate_datetime)]

class MyModel(BaseModel):
    dt: ValidatedDatetime = Field(gt=datetime.datetime(2022, 1, 1, tzinfo=datetime.timezone.utc))

class MyModelFactory(ModelFactory[MyModel]): ...

MyModelFactory.build()  # Fails: 'datetime.date' object has no attribute 'tzinfo'
```

## Root Cause

`datetime` is a subclass of `date`, so `is_safe_subclass(annotation, date)` matches for both types. The existing `handle_constrained_date` always returns a `date` via `faker.date_between`.

## Solution

1. Add `handle_constrained_datetime()` that returns proper `datetime` objects with timezone support (uses `faker.date_time_between`)
2. Check for `datetime` **before** `date` in the constraint resolution logic
3. Also handles boolean `tz` values from msgspec's `Meta` constraint

## Changes

| File | Change |
|------|--------|
| `polyfactory/value_generators/constrained_dates.py` | Add `handle_constrained_datetime()` function |
| `polyfactory/factories/base.py` | Check `datetime` before `date` in constraint handling |