### PR TITLE
fix(sqlalchemy): skip system columns during persistence

### DIFF
--- a/polyfactory/factories/sqlalchemy_factory.py
+++ b/polyfactory/factories/sqlalchemy_factory.py
@@ -48,10 +48,12 @@ T = TypeVar("T")
 
 class SQLAlchemyBuildContext(BaseBuildContext):
     skip_computed_fields: bool
+    skip_system_fields: bool
 
 
 class SQLAlchemyConstraints(Constraints):
     computed: NotRequired[bool]
+    system: NotRequired[bool]
 
 
 class SQLAlchemyPersistenceMethod(enum.Enum):
@@ -161,6 +163,8 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
         build_context = cast("SQLAlchemyBuildContext", super()._get_build_context(build_context))
         if build_context.get("skip_computed_fields") is None:
             build_context["skip_computed_fields"] = False
+        if build_context.get("skip_system_fields") is None:
+            build_context["skip_system_fields"] = False
 
         return build_context
 
@@ -168,6 +172,7 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
     def create_sync(cls, **kwargs: Any) -> T:
         build_context = cls._get_build_context(kwargs.get("_build_context"))
         build_context["skip_computed_fields"] = True
+        build_context["skip_system_fields"] = True
         kwargs["_build_context"] = build_context
         return super().create_sync(**kwargs)
 
@@ -175,6 +180,7 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
     async def create_async(cls, **kwargs: Any) -> T:
         build_context = cls._get_build_context(kwargs.get("_build_context"))
         build_context["skip_computed_fields"] = True
+        build_context["skip_system_fields"] = True
         kwargs["_build_context"] = build_context
         return await super().create_async(**kwargs)
 
@@ -239,6 +245,8 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
         if field_meta.constraints:
             constraints = cast("SQLAlchemyConstraints", field_meta.constraints)
             if constraints.get("computed") and build_context.get("skip_computed_fields"):
+                return False
+            if constraints.get("system") and build_context.get("skip_system_fields"):
                 return False
 
         return super().should_set_field_value(field_meta, **kwargs)
@@ -308,6 +316,10 @@ class SQLAlchemyFactory(Generic[T], BaseFactory[T]):
         if column.computed:
             constraints: SQLAlchemyConstraints = {"computed": True}
             annotation = Annotated[annotation, Frozendict(constraints)]  # type: ignore[assignment]
+
+        if getattr(column, "system", False):
+            system_constraints: SQLAlchemyConstraints = {"system": True}
+            annotation = Annotated[annotation, Frozendict(system_constraints)]  # type: ignore[assignment]
 
         return annotation
 


### PR DESCRIPTION
## Problem

Columns with `system=True` (e.g., PostgreSQL system columns) cause an `OperationalError` when using `create_sync`/`create_async` because the factory tries to persist values for these server-managed columns.

## Solution

Handle system columns the same way computed columns are already handled:

1. Detect `column.system` in `get_type_from_column` and annotate with a `{"system": True}` constraint
2. Skip system-constrained fields in `should_set_field_value` when `skip_system_fields` is set
3. Set `skip_system_fields=True` during `create_sync`/`create_async` (same as `skip_computed_fields`)

Values are still generated normally during `build()` — only persistence operations skip these fields.

## Files Changed

- `polyfactory/factories/sqlalchemy_factory.py`:
  - Added `system` to `SQLAlchemyConstraints`
  - Added `skip_system_fields` to `SQLAlchemyBuildContext`
  - Detect `system=True` columns in `get_type_from_column`
  - Skip system fields in `should_set_field_value` during persistence

Closes #802