### PR TITLE
fix: Constraints on annotated types are respected when calling coverage method.

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -894,7 +894,11 @@ class BaseFactory(ABC, Generic[T]):
             unwrapped_annotation_meta = field_meta
             if is_union(field_meta.annotation):
                 unwrapped_annotation_meta = next(
-                    (meta for meta in (field_meta.children or []) if meta.annotation == unwrapped_annotation),
+                    (
+                        meta
+                        for meta in (field_meta.children or [])
+                        if unwrap_annotation(meta.annotation) == unwrapped_annotation
+                    ),
                     field_meta,
                 )
             if unwrapped_annotation in (None, NoneType):

--- a/tests/test_type_coverage_generation.py
+++ b/tests/test_type_coverage_generation.py
@@ -1,5 +1,6 @@
 # ruff: noqa: UP007
 from __future__ import annotations
+from sys import version_info
 from annotated_types import Gt, Lt
 
 from collections.abc import Iterable
@@ -374,12 +375,13 @@ def test_optional_mixed_collections() -> None:
     assert type_exists_at_path_any(results, ["maybe_uuids"], NoneType)
 
 
+@pytest.mark.skipif(version_info < (3, 10), reason="Union with annotated and None not support on <3.10")
 def test_annotated_optional() -> None:
     # Struggling a bit on how to properly test this.
     # We are constraining random generation of an int value
-    # within a constraint. The actual constraint is actually under test
+    # The actual constraint is actually under test
     # here. But in case the constraint is not doing its job,
-    # there is a case where the generation falls within the constraint
+    # there is a possibility where the generation falls within the constraint
     # which actually results in a false positive.
     @dataclass
     class Model:

--- a/tests/test_type_coverage_generation.py
+++ b/tests/test_type_coverage_generation.py
@@ -383,7 +383,7 @@ def test_annotated_optional() -> None:
     # which actually results in a false positive.
     @dataclass
     class Model:
-        maybe_constraint_int: Optional[Annotated[int, Gt(0), Lt(3)]]
+        maybe_constraint_int: Annotated[int, Gt(0), Lt(3)] | None
 
     results = list(DataclassFactory.create_factory(Model).coverage())
 

--- a/tests/test_type_coverage_generation.py
+++ b/tests/test_type_coverage_generation.py
@@ -1,10 +1,11 @@
 # ruff: noqa: UP007
 from __future__ import annotations
+from annotated_types import Gt, Lt
 
 from collections.abc import Iterable
 from dataclasses import dataclass, make_dataclass
 from datetime import date
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal, Optional, Union, Annotated
 from uuid import UUID
 
 import pytest
@@ -371,3 +372,21 @@ def test_optional_mixed_collections() -> None:
     assert type_exists_at_path_any(results, ["maybe_uuids"], list)
     assert type_exists_at_path_any(results, ["maybe_uuids", "*"], UUID)
     assert type_exists_at_path_any(results, ["maybe_uuids"], NoneType)
+
+
+def test_annotated_optional() -> None:
+    # Struggling a bit on how to properly test this.
+    # We are constraining random generation of an int value
+    # within a constraint. The actual constraint is actually under test
+    # here. But in case the constraint is not doing its job,
+    # there is a case where the generation falls within the constraint
+    # which actually results in a false positive.
+    @dataclass
+    class Model:
+        maybe_constraint_int: Optional[Annotated[int, Gt(0), Lt(3)]]
+
+    results = list(DataclassFactory.create_factory(Model).coverage())
+
+    assert len(results) == 2
+    for result in results:
+        assert result.maybe_constraint_int in {1, 2, None}

--- a/tests/test_type_coverage_generation.py
+++ b/tests/test_type_coverage_generation.py
@@ -1,15 +1,15 @@
 # ruff: noqa: UP007
 from __future__ import annotations
-from sys import version_info
-from annotated_types import Gt, Lt
 
 from collections.abc import Iterable
 from dataclasses import dataclass, make_dataclass
 from datetime import date
-from typing import Any, Literal, Optional, Union, Annotated
+from sys import version_info
+from typing import Annotated, Any, Literal, Optional, Union
 from uuid import UUID
 
 import pytest
+from annotated_types import Gt, Lt
 from typing_extensions import TypedDict
 
 from pydantic import BaseModel


### PR DESCRIPTION
Fixes Annotated Optionals when used in the `.coverage` method.

Closes #854 

