### PR TITLE
fix: handle msgspec Meta tz bool constraint in date generator

### DIFF
--- a/polyfactory/value_generators/constrained_dates.py
+++ b/polyfactory/value_generators/constrained_dates.py
@@ -13,7 +13,7 @@ def handle_constrained_date(
     gt: date | None = None,
     le: date | None = None,
     lt: date | None = None,
-    tz: tzinfo = timezone.utc,
+    tz: tzinfo | bool = timezone.utc,
 ) -> date:
     """Generates a date value fulfilling the expected constraints.
 
@@ -22,10 +22,14 @@ def handle_constrained_date(
     :param le: Less than or equal value.
     :param gt: Greater than value.
     :param ge: Greater than or equal value.
-    :param tz: A timezone.
+    :param tz: A timezone (tzinfo) or a bool from msgspec.Meta tz constraint.
 
     :returns: A date instance.
     """
+    # Handle msgspec.Meta tz constraint which is a bool, not a tzinfo
+    if isinstance(tz, bool):
+        tz = timezone.utc if tz else None  # type: ignore[assignment]
+
     start_date = datetime.now(tz=tz).date() - timedelta(days=100)
     if ge:
         start_date = ge


### PR DESCRIPTION
## Summary\n\nFixes #768.\n\nThe `handle_constrained_date()` function in `polyfactory/value_generators/constrained_dates.py` received a `bool` for the `tz` parameter from msgspec's `Meta(tz=True)` constraint, but passed it directly to `datetime.now(tz=tz)` which expects a `tzinfo` object.\n\n## Changes\n\n- Updated `handle_constrained_date()` to accept `tz: tzinfo | bool` and convert bool values: `True` → `timezone.utc`, `False` → `None` (naive datetime)\n\n## Testing\n\nManually verified with the MCVE from the issue:\n\n```python\nfrom datetime import datetime\nfrom typing import Annotated\nfrom msgspec import Struct, Meta\nfrom polyfactory.factories.msgspec_factory import MsgspecFactory\n\nclass SomeStruct(Struct):\n    some_datetime: Annotated[datetime, Meta(tz=True)]\n\nclass SomeStructFactory(MsgspecFactory[SomeStruct]):...\n\nSomeStructFactory.build()  # Now works without TypeError\n```\n