### PR TITLE
fix: find more supporting BaseFactories for unsupported type

### DIFF
--- a/polyfactory/factories/base.py
+++ b/polyfactory/factories/base.py
@@ -245,10 +245,10 @@ class BaseFactory(ABC, Generic[T]):
                     raise ConfigurationException(
                         msg,
                     )
-                msg = f"Model type {model.__name__} is not supported. To support it, register an appropriate base factory and subclass it for your factory."
-                raise ConfigurationException(
-                    msg,
-                )
+            msg = f"Model type {model.__name__} is not supported. To support it, register an appropriate base factory and subclass it for your factory."
+            raise ConfigurationException(
+                msg,
+            )
 
     @classmethod
     def _get_build_context(cls, build_context: BuildContext | None) -> BuildContext:


### PR DESCRIPTION
With multiple registered BaseFactory classes,
only the first was considered for a helpful error message.

## Description
Found while reading the code on Github, was obviously just too much indentation or thought mistake.