### PR TITLE
fix: guard by_name kwarg for pydantic < 2.11

### DIFF
--- a/polyfactory/factories/pydantic_factory.py
+++ b/polyfactory/factories/pydantic_factory.py
@@ -92,6 +92,9 @@ except ImportError:
         from pydantic.v1.fields import DeferredType, ModelField, Undefined
 
 
+_PYDANTIC_HAS_BY_NAME = tuple(map(int, VERSION.split(".")[:2])) >= (2, 11)
+
+
 if TYPE_CHECKING:
     from collections import abc
     from collections.abc import Iterable, Mapping, Sequence
@@ -567,7 +570,9 @@ class ModelFactory(BaseFactory[T], Generic[T]):
 
         # Use model_validate with by_name for Pydantic v2 models when requested
         if cls.__by_name__ and _is_pydantic_v2_model(cls.__model__):
-            return cls.__model__.model_validate(kwargs, by_name=True)  # type: ignore[return-value]
+            if _PYDANTIC_HAS_BY_NAME:
+                return cls.__model__.model_validate(kwargs, by_name=True)  # type: ignore[return-value]
+            return cls.__model__.model_validate(kwargs)  # type: ignore[return-value]
 
         return cls.__model__(**kwargs)
 


### PR DESCRIPTION
Fix #882

Guard the `by_name=True` argument in `pydantic_factory.py` behind a pydantic
version check: `by_name` was added to `model_validate` in pydantic 2.11.0.
On pydantic < 2.11 the factory now falls back to a plain `model_validate`
call, so the declared minimum version range (`pydantic>=2.10.4`) works with
`__by_name__ = True` as well.