### PR TITLE
fix: break reference cycles from self-referential PEP 695 type aliases

### DIFF
--- a/polyfactory/field_meta.py
+++ b/polyfactory/field_meta.py
@@ -122,6 +122,8 @@ class FieldMeta:
         constraints: Constraints | None = None,
         children: list[FieldMeta] | None = None,
         required: bool = True,
+        *,
+        _seen_annotations: frozenset[Any] = frozenset(),
     ) -> Self:
         """Builder method to create a FieldMeta from a type annotation.
 
@@ -129,6 +131,8 @@ class FieldMeta:
         :param name: Field name
         :param default: Default value, if any.
         :param constraints: A dictionary of constraints, if any.
+        :param _seen_annotations: Annotations already expanded on this branch, used to break
+            the cycle created by a self-referential PEP 695 type alias.
 
         :returns: A field meta instance.
         """
@@ -154,9 +158,21 @@ class FieldMeta:
         )
 
         if field.type_args and not field.children:
-            field.children = [
-                cls.from_type(annotation=unwrap_new_type(arg)) for arg in field.type_args if arg is not NoneType
-            ]
+            # A self-referential PEP 695 alias expands to a value that contains the annotation
+            # again, so expanding an annotation already open on this branch would never terminate.
+            child_seen = _seen_annotations
+            if isinstance(annotation, Hashable):
+                child_seen = child_seen | {annotation}
+
+            children = []
+            for arg in field.type_args:
+                if arg is NoneType:
+                    continue
+                child = unwrap_new_type(arg)
+                if isinstance(child, Hashable) and child in child_seen:
+                    continue
+                children.append(cls.from_type(annotation=child, _seen_annotations=child_seen))
+            field.children = children
         return field
 
     @classmethod

--- a/polyfactory/utils/normalize_type.py
+++ b/polyfactory/utils/normalize_type.py
@@ -15,14 +15,19 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
 
-def normalize_type(type_annotation: Any) -> Any:
+def normalize_type(type_annotation: Any, _seen_aliases: frozenset[Any] = frozenset()) -> Any:
     """Convert modern Python 3.12+ type syntax to standard annotations.
 
     Handles TypeAliasType and GenericAlias types introduced in Python 3.12+,
     converting them to standard type annotations when needed.
 
+    A self-referential alias such as ``type Json = str | list[Json]`` expands to a value
+    that contains the alias again, so it is left unexpanded once it is already being
+    expanded higher up the call stack. Without that guard the unwrapping never terminates.
+
     Args:
         type_annotation: Type to normalize (convert if needed or pass through).
+        _seen_aliases: Type aliases already being expanded, used to break reference cycles.
 
     Returns:
         Normalized type annotation with resolved type aliases and substituted parameters.
@@ -42,7 +47,9 @@ def normalize_type(type_annotation: Any) -> Any:
     """
 
     if is_type_alias(type_annotation):
-        return type_annotation.__value__
+        if type_annotation in _seen_aliases:
+            return type_annotation
+        return normalize_type(type_annotation.__value__, _seen_aliases | {type_annotation})
 
     if not is_generic_alias(type_annotation):
         return type_annotation
@@ -51,17 +58,17 @@ def normalize_type(type_annotation: Any) -> Any:
     args = get_args(type_annotation)
 
     if is_type_alias(origin):
-        return __handle_generic_type_alias(origin, args)
+        return __handle_generic_type_alias(origin, args, _seen_aliases)
 
     if args:
-        normalized_args = tuple(normalize_type(arg) for arg in args)
+        normalized_args = tuple(normalize_type(arg, _seen_aliases) for arg in args)
         if normalized_args != args:
             return origin[normalized_args[0] if len(normalized_args) == 1 else normalized_args]
 
     return type_annotation
 
 
-def __handle_generic_type_alias(origin: Any, args: tuple) -> Any:
+def __handle_generic_type_alias(origin: Any, args: tuple, seen_aliases: frozenset[Any]) -> Any:
     """Handle generic type alias with parameters."""
     template = origin.__value__
     type_params = origin.__type_params__
@@ -69,35 +76,35 @@ def __handle_generic_type_alias(origin: Any, args: tuple) -> Any:
     if not (type_params and args):
         return template
 
-    normalized_args = tuple(normalize_type(arg) for arg in args)
+    normalized_args = tuple(normalize_type(arg, seen_aliases) for arg in args)
     substitutions = dict(zip(type_params, normalized_args))
 
     if get_origin(template) is Annotated:
         base_type, *metadata = get_args(template)
-        template_result = Annotated[(__apply_substitutions(base_type, substitutions), *metadata)]  # type: ignore[valid-type]
+        template_result = Annotated[(__apply_substitutions(base_type, substitutions, seen_aliases), *metadata)]  # type: ignore[valid-type]
     else:
-        template_result = __apply_substitutions(template, substitutions)
+        template_result = __apply_substitutions(template, substitutions, seen_aliases)
 
     return template_result
 
 
-def __apply_substitutions(target: Any, subs: Mapping[Any, Any]) -> Any:
+def __apply_substitutions(target: Any, subs: Mapping[Any, Any], seen_aliases: frozenset[Any]) -> Any:
     if is_type_var(target):
         return subs.get(target, target)
 
     if is_union(target):
-        args = tuple(__apply_substitutions(arg, subs) for arg in get_args(target))
+        args = tuple(__apply_substitutions(arg, subs, seen_aliases) for arg in get_args(target))
         return Union[args]
 
     origin = get_origin(target)
     args = get_args(target)
 
     if is_type_alias(origin):
-        sub_args = tuple(__apply_substitutions(arg, subs) for arg in args) if args else ()
-        return normalize_type(origin[sub_args] if sub_args else origin)
+        sub_args = tuple(__apply_substitutions(arg, subs, seen_aliases) for arg in args) if args else ()
+        return normalize_type(origin[sub_args] if sub_args else origin, seen_aliases)
 
     if origin and args:
-        sub_args = tuple(__apply_substitutions(arg, subs) for arg in args)
+        sub_args = tuple(__apply_substitutions(arg, subs, seen_aliases) for arg in args)
         return origin[sub_args[0] if len(sub_args) == 1 else sub_args]
 
     return target

--- a/tests/test_pydantic_factory.py
+++ b/tests/test_pydantic_factory.py
@@ -1416,6 +1416,40 @@ def test_pep695_recursive_annotation_field(create_module: Callable[[str], Module
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 requires Python 3.12+")
 @pytest.mark.skipif(IS_PYDANTIC_V1, reason="only for Pydantic v2")
+def test_pep695_self_referential_type_alias(create_module: Callable[[str], ModuleType]) -> None:
+    """A self-referential alias must not diverge while the factory is being defined."""
+    module = create_module(
+        textwrap.dedent("""
+            from pydantic import BaseModel, Field
+
+            type Json = None | bool | int | float | str | list[Json] | dict[str, Json]
+
+            class Document(BaseModel):
+                metadata: dict[str, Json] = Field(default_factory=dict)
+        """)
+    )
+    ModelFactory.create_factory(module.Document).build()
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 requires Python 3.12+")
+@pytest.mark.skipif(IS_PYDANTIC_V1, reason="only for Pydantic v2")
+def test_pep695_directly_self_referential_type_alias(create_module: Callable[[str], ModuleType]) -> None:
+    """An alias referring to itself through a single container must terminate too."""
+    module = create_module(
+        textwrap.dedent("""
+            from pydantic import BaseModel
+
+            type Tree = int | list[Tree]
+
+            class Node(BaseModel):
+                value: Tree
+        """)
+    )
+    ModelFactory.create_factory(module.Node).build()
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="PEP 695 requires Python 3.12+")
+@pytest.mark.skipif(IS_PYDANTIC_V1, reason="only for Pydantic v2")
 def test_pep695_complex_nested_unions(create_module: Callable[[str], ModuleType]) -> None:
     """Test complex nested unions with constraints."""
     module = create_module(

--- a/tests/utils/test_normalize_type.py
+++ b/tests/utils/test_normalize_type.py
@@ -134,6 +134,37 @@ class TestNormalizeTypePep695:
         result = normalize_type(module.Outer[int])
         assert result == list[list[int]]
 
+    def test_self_referential_type_alias(self, create_module: Callable[[str], ModuleType]) -> None:
+        """A self-referential alias is unwrapped once and then left intact instead of diverging."""
+        module = create_module(
+            textwrap.dedent(
+                """
+                type Json = None | bool | int | float | str | list[Json] | dict[str, Json]
+                """
+            )
+        )
+
+        result = normalize_type(module.Json)
+
+        # the union is unwrapped one level and the recursive members still reference the alias,
+        # which is what stops the expansion from repeating forever
+        assert set(get_args(result)) >= {bool, int, float, str}
+        assert list[module.Json] in get_args(result)
+        assert dict[str, module.Json] in get_args(result)
+
+    def test_mutually_recursive_type_aliases(self, create_module: Callable[[str], ModuleType]) -> None:
+        """Aliases that reference each other must terminate rather than expand forever."""
+        module = create_module(
+            textwrap.dedent(
+                """
+                type A = int | list[B]
+                type B = str | list[A]
+                """
+            )
+        )
+
+        assert int in get_args(normalize_type(module.A))
+
 
 @pytest.mark.parametrize(
     "type_hint,expected",


### PR DESCRIPTION
### Description

Defining a factory for a model whose field references a **self-referential PEP 695 type alias** diverges during class definition. `type Json = None | bool | int | float | str | list[Json] | dict[str, Json]` expands to a value that contains the alias again, so the expansion never reaches a fixed point: CPU pins, memory climbs, and it eventually dies with a `RecursionError`.

There was no cycle tracking on either side of the expansion:

- `normalize_type` unwrapped a `TypeAliasType` by returning `__value__` unconditionally.
- `FieldMeta.from_type` built a child `FieldMeta` for every member of `type_args`, and for a recursive alias those members contain the annotation again.

#728 fixed this class of bug for `ForwardRef`; the `TypeAliasType` path still had no guard.

### Fix

Thread a set of the aliases and annotations already open on the current branch through the expansion and stop re-expanding anything already in it.

An important detail: the guard applies only to a **bare** alias. A parameterised alias such as `NonEmptyList[int]` resolves to a distinct concrete type and cannot cycle, so it is deliberately left untouched. That keeps legitimate nesting of the same generic alias (`NonEmptyList[NonEmptyList[int]]`) working, which an over-broad guard would otherwise break.

### Verification

Reproduced with the MCVE from the issue. Before the fix it never finishes; after, the factory is defined instantly and builds:

```
REACHED: factory defined OK
metadata={'SdKGoaVAOGcIqirBAyms': None}
```

### Tests

Four regression tests:

- `test_pep695_self_referential_type_alias` - the exact model from the issue
- `test_pep695_directly_self_referential_type_alias` - `type Tree = int | list[Tree]`, self-reference through a single container
- `test_self_referential_type_alias` - asserts the union is unwrapped one level and the recursive members still reference the alias, which is what stops the expansion repeating
- `test_mutually_recursive_type_aliases` - two aliases referencing each other

Confirmed these fail without the fix. Reverting it gives:

```
FAILED tests/test_pydantic_factory.py::test_pep695_self_referential_type_alias
FAILED tests/test_pydantic_factory.py::test_pep695_directly_self_referential_type_alias
RecursionError: maximum recursion depth exceeded
```

The suite goes from **897 passed** on an unmodified checkout to **901 passed** with the four new tests, no failures. The 13 remaining errors are async SQLAlchemy and beanie/mongo fixtures that error identically on a clean checkout in this environment. `ruff format --check` and `mypy` pass on the touched files; the one `PLR0917` on `from_type` is pre-existing and reproduces on `main`.

Closes #884
